### PR TITLE
move mod into proper spot in file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@ pub mod maestro;
 pub mod maestro_constants;
 mod utils;
 pub mod prelude;
-
-/* internal uses */
-
 #[cfg(test)]
 mod tests {
     /* external uses */
@@ -35,3 +32,5 @@ mod tests {
         maestro.close();
     }
 }
+
+/* internal uses */


### PR DESCRIPTION
mod was in incorrect spot; moved it into the appropriate place.