### PR TITLE
Fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # v0.2.0
 
 ## Changes:
+Note that all dates are in DD/MM/YYYY form.
 
-### 04/17/21
+### 04/17/2021
 * added legal copyright notations to the top of every source code file
 
-### 04/13/21
+### 04/13/2021
 * improved API design:
 	* relocated read/write buffers in Maestro struct instead of localized buffers in each API
 	* all requests supported by Polulu Micro Maestro 6-Channel (i.e., set\_target, get\_position, etc.) implemented
 	* get requests (i.e., get\_position, get\_errors) return a u16 instead of a reference to the internal read buffer
 
-## Todo
-* finish documentation for all functions
-* add custom error type for raestro; as of current, std::io::Error is being used
+### 05/01/2021
+* finished documentation for all public modules and exports
+* formatted library using rustfmt (all formatting rules can be found in rustfmt.toml)
+* fixed implementation for raestro::constants::Errors
+	* when an error or errors are encountered, the Maestro returns a 2-byte (u16) integer in which each of the first 9 positions (i.e., bit 0 to bit 8) represent an error
+	* if the bit in position i (where i = 0..=8) is set, then the according error was thrown by the Maestro
+	* previous implementation of constants::Errors assumed that each error had a specific number attached to it (i.e., SER_SIGNAL_ERR was 0, SER_BUFFER_ERR was 1, etc.), which is incorrect

--- a/examples/get_position.rs
+++ b/examples/get_position.rs
@@ -5,18 +5,15 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external crates */
+// external crates
 
-/* external uses */
-use std::{
-    thread,
-    time::Duration,
-};
+// external uses
 use raestro::prelude::*;
+use std::{thread, time::Duration};
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
+// internal uses
 
 fn main() -> () {
     let mut maestro: Maestro = Maestro::new();

--- a/examples/get_position.rs
+++ b/examples/get_position.rs
@@ -28,39 +28,20 @@ fn main() -> () {
     let pos_min = 992u16;
     let pos_max = 2000u16;
 
-    let sleep_time =
-        Duration::from_millis(1000u64);
+    let sleep_time = Duration::from_millis(1000u64);
 
     #[allow(unused_assignments)]
     let mut current_position: Option<u16> = None;
 
     loop {
-        maestro
-            .set_target(channel, pos_min)
-            .unwrap();
-        current_position = Some(
-            maestro
-                .get_position(channel)
-                .unwrap(),
-        );
-        println!(
-            "current position: {:?}",
-            current_position.unwrap()
-        );
+        maestro.set_target(channel, pos_min).unwrap();
+        current_position = Some(maestro.get_position(channel).unwrap());
+        println!("current position: {:?}", current_position.unwrap());
         thread::sleep(sleep_time);
 
-        maestro
-            .set_target(channel, pos_max)
-            .unwrap();
-        current_position = Some(
-            maestro
-                .get_position(channel)
-                .unwrap(),
-        );
-        println!(
-            "current position: {:?}",
-            current_position.unwrap()
-        );
+        maestro.set_target(channel, pos_max).unwrap();
+        current_position = Some(maestro.get_position(channel).unwrap());
+        println!("current position: {:?}", current_position.unwrap());
         thread::sleep(sleep_time);
     }
 }

--- a/examples/get_position.rs
+++ b/examples/get_position.rs
@@ -2,14 +2,18 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external crates
 
 // external uses
+use std::{
+    thread,
+    time::Duration,
+};
+
 use raestro::prelude::*;
-use std::{thread, time::Duration};
 
 // internal mods
 
@@ -24,20 +28,39 @@ fn main() -> () {
     let pos_min = 992u16;
     let pos_max = 2000u16;
 
-    let sleep_time = Duration::from_millis(1000u64);
+    let sleep_time =
+        Duration::from_millis(1000u64);
 
     #[allow(unused_assignments)]
     let mut current_position: Option<u16> = None;
 
     loop {
-        maestro.set_target(channel, pos_min).unwrap();
-        current_position = Some(maestro.get_position(channel).unwrap());
-        println!("current position: {:?}", current_position.unwrap());
+        maestro
+            .set_target(channel, pos_min)
+            .unwrap();
+        current_position = Some(
+            maestro
+                .get_position(channel)
+                .unwrap(),
+        );
+        println!(
+            "current position: {:?}",
+            current_position.unwrap()
+        );
         thread::sleep(sleep_time);
 
-        maestro.set_target(channel, pos_max).unwrap();
-        current_position = Some(maestro.get_position(channel).unwrap());
-        println!("current position: {:?}", current_position.unwrap());
+        maestro
+            .set_target(channel, pos_max)
+            .unwrap();
+        current_position = Some(
+            maestro
+                .get_position(channel)
+                .unwrap(),
+        );
+        println!(
+            "current position: {:?}",
+            current_position.unwrap()
+        );
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_acceleration.rs
+++ b/examples/set_acceleration.rs
@@ -5,18 +5,15 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external crates */
+// external crates
 
-/* external uses */
-use std::{
-    thread,
-    time::Duration,
-};
+// external uses
 use raestro::prelude::*;
+use std::{thread, time::Duration};
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
+// internal uses
 
 fn main() -> () {
     let mut maestro: Maestro = Maestro::new();

--- a/examples/set_acceleration.rs
+++ b/examples/set_acceleration.rs
@@ -2,14 +2,18 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external crates
 
 // external uses
+use std::{
+    thread,
+    time::Duration,
+};
+
 use raestro::prelude::*;
-use std::{thread, time::Duration};
 
 // internal mods
 
@@ -27,15 +31,24 @@ fn main() -> () {
     let pos0 = 992u16;
     let pos1 = 2000u16;
 
-    let sleep_time = Duration::from_millis(5000u64);
+    let sleep_time =
+        Duration::from_millis(5000u64);
 
     loop {
-        maestro.set_acceleration(channel, accel0).unwrap();
-        maestro.set_target(channel, pos0).unwrap();
+        maestro
+            .set_acceleration(channel, accel0)
+            .unwrap();
+        maestro
+            .set_target(channel, pos0)
+            .unwrap();
         thread::sleep(sleep_time);
 
-        maestro.set_acceleration(channel, accel1).unwrap();
-        maestro.set_target(channel, pos1).unwrap();
+        maestro
+            .set_acceleration(channel, accel1)
+            .unwrap();
+        maestro
+            .set_target(channel, pos1)
+            .unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_acceleration.rs
+++ b/examples/set_acceleration.rs
@@ -31,24 +31,15 @@ fn main() -> () {
     let pos0 = 992u16;
     let pos1 = 2000u16;
 
-    let sleep_time =
-        Duration::from_millis(5000u64);
+    let sleep_time = Duration::from_millis(5000u64);
 
     loop {
-        maestro
-            .set_acceleration(channel, accel0)
-            .unwrap();
-        maestro
-            .set_target(channel, pos0)
-            .unwrap();
+        maestro.set_acceleration(channel, accel0).unwrap();
+        maestro.set_target(channel, pos0).unwrap();
         thread::sleep(sleep_time);
 
-        maestro
-            .set_acceleration(channel, accel1)
-            .unwrap();
-        maestro
-            .set_target(channel, pos1)
-            .unwrap();
+        maestro.set_acceleration(channel, accel1).unwrap();
+        maestro.set_target(channel, pos1).unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_speed.rs
+++ b/examples/set_speed.rs
@@ -31,24 +31,15 @@ fn main() -> () {
     let pos0 = 992u16;
     let pos1 = 2000u16;
 
-    let sleep_time =
-        Duration::from_millis(1000u64);
+    let sleep_time = Duration::from_millis(1000u64);
 
     loop {
-        maestro
-            .set_speed(channel, speed0)
-            .unwrap();
-        maestro
-            .set_target(channel, pos0)
-            .unwrap();
+        maestro.set_speed(channel, speed0).unwrap();
+        maestro.set_target(channel, pos0).unwrap();
         thread::sleep(sleep_time);
 
-        maestro
-            .set_speed(channel, speed1)
-            .unwrap();
-        maestro
-            .set_target(channel, pos1)
-            .unwrap();
+        maestro.set_speed(channel, speed1).unwrap();
+        maestro.set_target(channel, pos1).unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_speed.rs
+++ b/examples/set_speed.rs
@@ -5,18 +5,15 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external crates */
+// external crates
 
-/* external uses */
-use std::{
-    thread,
-    time::Duration,
-};
+// external uses
 use raestro::prelude::*;
+use std::{thread, time::Duration};
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
+// internal uses
 
 fn main() -> () {
     let mut maestro: Maestro = Maestro::new();

--- a/examples/set_speed.rs
+++ b/examples/set_speed.rs
@@ -2,14 +2,18 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external crates
 
 // external uses
+use std::{
+    thread,
+    time::Duration,
+};
+
 use raestro::prelude::*;
-use std::{thread, time::Duration};
 
 // internal mods
 
@@ -27,15 +31,24 @@ fn main() -> () {
     let pos0 = 992u16;
     let pos1 = 2000u16;
 
-    let sleep_time = Duration::from_millis(1000u64);
+    let sleep_time =
+        Duration::from_millis(1000u64);
 
     loop {
-        maestro.set_speed(channel, speed0).unwrap();
-        maestro.set_target(channel, pos0).unwrap();
+        maestro
+            .set_speed(channel, speed0)
+            .unwrap();
+        maestro
+            .set_target(channel, pos0)
+            .unwrap();
         thread::sleep(sleep_time);
 
-        maestro.set_speed(channel, speed1).unwrap();
-        maestro.set_target(channel, pos1).unwrap();
+        maestro
+            .set_speed(channel, speed1)
+            .unwrap();
+        maestro
+            .set_target(channel, pos1)
+            .unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_target.rs
+++ b/examples/set_target.rs
@@ -5,18 +5,15 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external crates */
+// external crates
 
-/* external uses */
-use std::{
-    thread,
-    time::Duration,
-};
+// external uses
 use raestro::prelude::*;
+use std::{thread, time::Duration};
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
+// internal uses
 
 fn main() -> () {
     let mut maestro: Maestro = Maestro::new();

--- a/examples/set_target.rs
+++ b/examples/set_target.rs
@@ -2,14 +2,18 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external crates
 
 // external uses
+use std::{
+    thread,
+    time::Duration,
+};
+
 use raestro::prelude::*;
-use std::{thread, time::Duration};
 
 // internal mods
 
@@ -26,17 +30,30 @@ fn main() -> () {
     let pos_min = 992u16;
     let pos_max = 2000u16;
 
-    let sleep_time = Duration::from_millis(1000u64);
+    let sleep_time =
+        Duration::from_millis(1000u64);
 
     loop {
-        maestro.set_target(channel0, pos_min).unwrap();
-        maestro.set_target(channel1, pos_min).unwrap();
-        maestro.set_target(channel2, pos_min).unwrap();
+        maestro
+            .set_target(channel0, pos_min)
+            .unwrap();
+        maestro
+            .set_target(channel1, pos_min)
+            .unwrap();
+        maestro
+            .set_target(channel2, pos_min)
+            .unwrap();
         thread::sleep(sleep_time);
 
-        maestro.set_target(channel0, pos_max).unwrap();
-        maestro.set_target(channel1, pos_max).unwrap();
-        maestro.set_target(channel2, pos_max).unwrap();
+        maestro
+            .set_target(channel0, pos_max)
+            .unwrap();
+        maestro
+            .set_target(channel1, pos_max)
+            .unwrap();
+        maestro
+            .set_target(channel2, pos_max)
+            .unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/set_target.rs
+++ b/examples/set_target.rs
@@ -30,30 +30,17 @@ fn main() -> () {
     let pos_min = 992u16;
     let pos_max = 2000u16;
 
-    let sleep_time =
-        Duration::from_millis(1000u64);
+    let sleep_time = Duration::from_millis(1000u64);
 
     loop {
-        maestro
-            .set_target(channel0, pos_min)
-            .unwrap();
-        maestro
-            .set_target(channel1, pos_min)
-            .unwrap();
-        maestro
-            .set_target(channel2, pos_min)
-            .unwrap();
+        maestro.set_target(channel0, pos_min).unwrap();
+        maestro.set_target(channel1, pos_min).unwrap();
+        maestro.set_target(channel2, pos_min).unwrap();
         thread::sleep(sleep_time);
 
-        maestro
-            .set_target(channel0, pos_max)
-            .unwrap();
-        maestro
-            .set_target(channel1, pos_max)
-            .unwrap();
-        maestro
-            .set_target(channel2, pos_max)
-            .unwrap();
+        maestro.set_target(channel0, pos_max).unwrap();
+        maestro.set_target(channel1, pos_max).unwrap();
+        maestro.set_target(channel2, pos_max).unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/stop_script.rs
+++ b/examples/stop_script.rs
@@ -28,24 +28,15 @@ fn main() -> () {
     let pos0 = 992u16;
     let pos1 = 2000u16;
 
-    let sleep_time =
-        Duration::from_millis(1000u64);
+    let sleep_time = Duration::from_millis(1000u64);
 
     loop {
-        maestro
-            .set_target(channel, pos0)
-            .unwrap();
-        maestro
-            .stop_script()
-            .unwrap();
+        maestro.set_target(channel, pos0).unwrap();
+        maestro.stop_script().unwrap();
         thread::sleep(sleep_time);
 
-        maestro
-            .set_target(channel, pos1)
-            .unwrap();
-        maestro
-            .stop_script()
-            .unwrap();
+        maestro.set_target(channel, pos1).unwrap();
+        maestro.stop_script().unwrap();
         thread::sleep(sleep_time);
     }
 }

--- a/examples/stop_script.rs
+++ b/examples/stop_script.rs
@@ -1,0 +1,51 @@
+// Copyright 2021 UBC Bionics, Ltd.
+//
+// Licensed under the MIT license
+// <LICENSE.md or https://opensource.org/licenses/MIT>.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
+
+// external crates
+
+// external uses
+use std::{
+    thread,
+    time::Duration,
+};
+
+use raestro::prelude::*;
+
+// internal mods
+
+// internal uses
+
+fn main() -> () {
+    let mut maestro: Maestro = Maestro::new();
+    maestro.start(BaudRates::BR_115200).unwrap();
+
+    let channel: Channels = Channels::C_0;
+
+    let pos0 = 992u16;
+    let pos1 = 2000u16;
+
+    let sleep_time =
+        Duration::from_millis(1000u64);
+
+    loop {
+        maestro
+            .set_target(channel, pos0)
+            .unwrap();
+        maestro
+            .stop_script()
+            .unwrap();
+        thread::sleep(sleep_time);
+
+        maestro
+            .set_target(channel, pos1)
+            .unwrap();
+        maestro
+            .stop_script()
+            .unwrap();
+        thread::sleep(sleep_time);
+    }
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -28,7 +28,8 @@ match_block_trailing_comma = true
 
 # Function
 fn_single_line = true
-fn_args_layout = "Compressed"
+fn_args_layout = "Tall"
+fn_call_width = 60
 
 # Imports
 reorder_imports = true
@@ -55,8 +56,8 @@ edition = "2018"
 use_field_init_shorthand = true
 
 # General
-max_width = 50
-use_small_heuristics = "Off"
+max_width = 100
+use_small_heuristics = "Default"
 overflow_delimited_expr = true
 blank_lines_upper_bound = 2
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,32 +1,67 @@
 # This rustfmt file is added for configuration, but in practice much of our
 # code is hand-formatted, frequently with more readable results.
 
+# Todo: report_todo and report_fixme
+
+# Modules
+reorder_modules = true
+reorder_impl_items = true
+merge_derives = true
+
+# Style
+## Braces
+brace_style = "SameLineWhere"
+
+## Spaces
+tab_spaces = 4
+spaces_around_ranges = false
+space_before_colon = false
+space_after_colon = true
+inline_attribute_width = 0
+indent_style = "Block"
+
+## Punctuation
+type_punctuation_density = "Wide"
+trailing_semicolon = true
+trailing_comma = "Vertical"
+match_block_trailing_comma = true
+
+# Function
+fn_single_line = true
+fn_args_layout = "Compressed"
+
+# Imports
+reorder_imports = true
+imports_granularity = "Crate"
+imports_layout = "Vertical"
+imports_indent = "Block"
+group_imports = "StdExternalCrate"
+
 # Comments:
 normalize_comments = true
-wrap_comments = false
-comment_width = 90      # small excess is okay but prefer 80
+wrap_comments = true
+normalize_doc_attributes = true
+comment_width = 90
+report_todo = "Unnumbered"
+report_fixme = "Unnumbered"
 
-# Arguments:
-use_small_heuristics = "Default"
-# TODO: single line functions only where short, please?
-# https://github.com/rust-lang/rustfmt/issues/3358
-fn_single_line = false
-fn_args_layout = "Compressed"
+# Where Clauses
+where_single_line = false
+
+# Compatibility
+edition = "2018"
+
+# TODO
+use_field_init_shorthand = true
+
+# General
+max_width = 50
+use_small_heuristics = "Off"
 overflow_delimited_expr = true
-where_single_line = true
+blank_lines_upper_bound = 2
+
+# Ignored
+ignore = []
 
 # enum_discrim_align_threshold = 20
 # struct_field_align_threshold = 20
-
-# Compatibility:
-edition = "2018"        # we require compatibility back to 1.32.0
-
-# Misc:
-inline_attribute_width = 80
-blank_lines_upper_bound = 2
-reorder_impl_items = true
-# report_todo = "Unnumbered"
-# report_fixme = "Unnumbered"
-
-# Ignored files:
-ignore = []

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -29,7 +29,8 @@ match_block_trailing_comma = true
 # Function
 fn_single_line = true
 fn_args_layout = "Tall"
-fn_call_width = 60
+# fn_call_width = 60
+force_multiline_blocks = false
 
 # Imports
 reorder_imports = true
@@ -42,9 +43,9 @@ group_imports = "StdExternalCrate"
 normalize_comments = true
 wrap_comments = true
 normalize_doc_attributes = true
-comment_width = 90
-report_todo = "Unnumbered"
-report_fixme = "Unnumbered"
+comment_width = 50
+# report_todo = "Unnumbered"
+# report_fixme = "Unnumbered"
 
 # Where Clauses
 where_single_line = false

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,7 +10,10 @@
 //! Pololu-Protocol.
 //!
 //! The specifics on the Pololu-Protoco, as well
-//! as the overall serial communication with the Maestro, can be found in the Pololu Micro-Maestro manual, located [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
+//! as the overall serial communication with the
+//! Maestro, can be found in the Pololu
+//! Micro-Maestro manual, located
+//! [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
 //! in section 5.e.
 
 use std::vec::Vec;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,11 +12,11 @@
 //! with the Maestro, can be found in the Pololu Micro-Maestro manual, located [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
 //! in section 5.e.
 
-/* external uses */
+// external uses
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
+// internal uses
 
 pub(crate) const SYNC: u8 = 0xaau8;
 pub(crate) const DEVICE_NUMBER: u8 = 0x0cu8;
@@ -123,13 +123,14 @@ pub enum Errors {
 }
 
 impl From<u16> for Errors {
-
     /// Converts a raw `u16` into an `Errors` type.
     ///
     /// Given that the underlying `Errors` types are represented by `u16s`, the conversion should not
     /// result in any undefined or erroneous behaviour.
     fn from(data: u16) -> Self {
-        return if (data >= (Errors::SER_SIGNAL_ERR as u16)) && (data <= (Errors::SCRIPT_PC_ERR as u16)) {
+        return if (data >= (Errors::SER_SIGNAL_ERR as u16))
+            && (data <= (Errors::SCRIPT_PC_ERR as u16))
+        {
             unsafe { std::mem::transmute(data) }
         } else {
             panic!()

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,11 +13,7 @@
 //! as the overall serial communication with the Maestro, can be found in the Pololu Micro-Maestro manual, located [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
 //! in section 5.e.
 
-// external uses
-
-// internal mods
-
-// internal uses
+use std::vec::Vec;
 
 pub(crate) const SYNC: u8 = 0xaau8;
 pub(crate) const DEVICE_NUMBER: u8 = 0x0cu8;
@@ -61,8 +57,7 @@ pub(crate) enum CommandFlags {
     GO_HOME = 0xA2u8,
     STOP_SCRIPT = 0xA4u8,
     RESTART_SCRIPT_AT_SUBROUTINE = 0xA7u8,
-    RESTART_SCRIPT_AT_SUBROUTINE_WITH_PARAMETER =
-        0xA8u8,
+    RESTART_SCRIPT_AT_SUBROUTINE_WITH_PARAMETER = 0xA8u8,
     GET_SCRIPT_STATUS = 0xAEu8,
 }
 
@@ -97,8 +92,11 @@ pub enum Channels {
 /// Available baudrates supported by the Maestro.
 ///
 /// Note that not all baudrates have been
-/// specified. # TODO
-/// Add all remaining baudrates to the enum below.
+/// specified.
+///
+/// # TODO
+/// Add all remaining baudrates to the enum
+/// below.
 ///
 /// Review existing docs for this enum and add
 /// more iff necessary.
@@ -115,24 +113,134 @@ pub enum BaudRates {
 
 /// All available errors throwable by the Maestro.
 ///
+/// For each Errors variant down below, the
+/// documentation provided was taken directly
+/// from section 4.e of the Pololu Micro Maestro
+/// manual, which can be found
+/// [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf).
+///
 /// # TODO
 /// Review existing docs for this enum and add
 /// more iff necessary.
 ///
 /// ADD DOCUMENTATION FOR ALL VARIANTS DOWN BELOW!
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(u16)]
 pub enum Errors {
+    /// A hardware-level error that occurs when a
+    /// byte’s stop bit is not detected at the
+    /// expected place. This can occur if you are
+    /// communicating at a baud rate that differs
+    /// from the Maestro’s baud rate.
     SER_SIGNAL_ERR = 0u16,
+
+    /// A hardware-level error that occurs when
+    /// the UART’s internal buffer fills up. This
+    /// should not occur during normal operation.
     SER_OVERRUN_ERR = 1u16,
+
+    /// A firmware-level error that occurs when
+    /// the firmware’s buffer for bytes received
+    /// on the RX line is full and a byte from RX
+    /// has been lost as a result. This error
+    /// should not occur during normal operation.
     SER_BUFFER_FULL = 2u16,
+
+    /// This error occurs when the Maestro is
+    /// running in CRC-enabled mode and the cyclic
+    /// redundancy check (CRC) byte at the end of
+    /// the command packet does not match what the
+    /// Maestro has computed as that packet’s CRC
+    /// (Section 5.d). In such a case, the Maestro
+    /// ignores the command packet and generates a
+    /// CRC error.
     SER_CRC_ERR = 3u16,
+
+    /// This error occurs when the Maestro
+    /// receives an incorrectly formatted or
+    /// nonsensical command packet. For example,
+    /// if the command byte does not match a known
+    /// command or an unfinished command packet is
+    /// interrupted by another command packet,
+    /// this error occurs.
     SER_PROTOCOL_ERR = 4u16,
+
+    /// When the serial timeout is enabled, this
+    /// error occurs whenever the timeout period
+    /// has elapsed without the Maestro receiving
+    /// any valid serial commands. This timeout
+    /// error can be used to make the servos
+    /// return to their home positions in the
+    /// event that serial communication between
+    /// the Maestro and its controller is
+    /// disrupted.
     SER_TIMEOUT = 5u16,
+
+    /// This error occurs when a bug in the user
+    /// script has caused the stack to overflow or
+    /// underflow. Any script command that
+    /// modifies the stack has the potential to
+    /// cause this error. The stack depth is 32 on
+    /// the Micro Maestro and 126 on the Mini
+    /// Maestros.
     SCRIPT_STACK_ERR = 6u16,
+
+    /// This error occurs when a bug in the user
+    /// script has caused the call stack to
+    /// overflow or underflow. An overflow can
+    /// occur if there are too many levels of
+    /// nested subroutines, or a subroutine calls
+    /// itself too many times. The call stack
+    /// depth is 10 on the Micro Maestro and 126
+    /// on the Mini Maestros. An underflow can
+    /// occur when there is a return without a
+    /// corresponding subroutine call. An
+    /// underflow will occur if you run a
+    /// subroutine using the “Restart Script at
+    /// Subroutine” serial command and the
+    /// subroutine terminates with a return
+    /// command rather than a quit command or an
+    /// infinite loop.
     SCRIPT_CALL_STACK_ERR = 7u16,
+
+    /// This error occurs when a bug in the user
+    /// script has caused the program counter (the
+    /// address of the next instruction to be
+    /// executed) to go out of bounds. This can
+    /// happen if your program is not terminated
+    /// by a quit, return, or infinite loop.
     SCRIPT_PC_ERR = 8u16,
+}
+
+impl Errors {
+    /// Converts the `u16` returned from the
+    /// Maestro that represents an error into a
+    /// vector of Errors. Each bit-position in
+    /// the `u16` represents a specific error, and
+    /// whether or not the bit is set or cleared
+    /// represents whether or not that specific
+    /// error was encounted. There exist only
+    /// 9 possible Maestro error, and as such,
+    /// only the first 9 bits (bit 0 to bit 8) can
+    /// be set in the `u16`. All other bits
+    /// are ignored.
+    pub fn into_errors(mut data: u16) -> Vec<Errors> {
+        #[allow(unused)]
+        const MASK: u16 = 0x0001u16;
+
+        let mut vec = Vec::with_capacity(9usize);
+
+        for i in 0u16..=8u16 {
+            if (data & MASK) == MASK {
+                vec.push(i.into());
+            };
+
+            data >>= 1usize;
+        }
+
+        return vec;
+    }
 }
 
 impl From<u16> for Errors {
@@ -144,14 +252,78 @@ impl From<u16> for Errors {
     /// conversion should not result in any
     /// undefined or erroneous behaviour.
     fn from(data: u16) -> Self {
-        return if (data
-            >= (Errors::SER_SIGNAL_ERR as u16))
-            && (data
-                <= (Errors::SCRIPT_PC_ERR as u16))
+        return if (data >= (Errors::SER_SIGNAL_ERR as u16))
+            && (data <= (Errors::SCRIPT_PC_ERR as u16))
         {
             unsafe { std::mem::transmute(data) }
         } else {
             panic!()
         };
+    }
+}
+
+#[cfg(test)]
+mod errors_test {
+    use super::*;
+
+    #[test]
+    fn no_errors() -> () {
+        let err = 0u16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 0usize);
+    }
+
+    #[test]
+    fn ser_signal_error() -> () {
+        let err = 1u16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 1usize);
+        assert_eq!(actual_vec[0usize], Errors::SER_SIGNAL_ERR);
+    }
+
+    #[test]
+    fn ser_overrun_error() -> () {
+        let err = 2u16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 1usize);
+        assert_eq!(actual_vec[0usize], Errors::SER_OVERRUN_ERR);
+    }
+
+    #[test]
+    fn two_errors() -> () {
+        let err = 3u16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 2usize);
+        assert_eq!(actual_vec[0usize], Errors::SER_SIGNAL_ERR);
+        assert_eq!(actual_vec[1usize], Errors::SER_OVERRUN_ERR);
+    }
+
+    #[test]
+    fn invalid_err() -> () {
+        let err = 0x0200u16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 0usize);
+    }
+
+    #[test]
+    fn all_errors() -> () {
+        let err = 0x01ffu16;
+        let actual_vec = Errors::into_errors(err);
+
+        assert_eq!(actual_vec.len(), 9usize);
+        assert_eq!(actual_vec[0usize], Errors::SER_SIGNAL_ERR);
+        assert_eq!(actual_vec[1usize], Errors::SER_OVERRUN_ERR);
+        assert_eq!(actual_vec[2usize], Errors::SER_BUFFER_FULL);
+        assert_eq!(actual_vec[3usize], Errors::SER_CRC_ERR);
+        assert_eq!(actual_vec[4usize], Errors::SER_PROTOCOL_ERR);
+        assert_eq!(actual_vec[5usize], Errors::SER_TIMEOUT);
+        assert_eq!(actual_vec[6usize], Errors::SCRIPT_STACK_ERR);
+        assert_eq!(actual_vec[7usize], Errors::SCRIPT_CALL_STACK_ERR);
+        assert_eq!(actual_vec[8usize], Errors::SCRIPT_PC_ERR);
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,14 +2,15 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
-//! All constants defined and used by the Maestro for `UART` communication
-//! through the Pololu-Protocol.
+//! All constants defined and used by the Maestro
+//! for `UART` communication through the
+//! Pololu-Protocol.
 //!
-//! The specifics on the Pololu-Protoco, as well as the overall serial communication
-//! with the Maestro, can be found in the Pololu Micro-Maestro manual, located [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
+//! The specifics on the Pololu-Protoco, as well
+//! as the overall serial communication with the Maestro, can be found in the Pololu Micro-Maestro manual, located [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf)
 //! in section 5.e.
 
 // external uses
@@ -26,20 +27,28 @@ pub(crate) const MIN_WRITE_LENGTH: usize = 3usize;
 pub(crate) const RESPONSE_SIZE: u8 = 2u8;
 pub(crate) const DATA_MULTIPLIER: usize = 2usize;
 
-/// The minimum PWM that can be sent to any channel by the Maestro.
+/// The minimum PWM that can be sent to any
+/// channel by the Maestro.
 ///
-/// All values below `MIN_PWM` being used as parameters to `set_target` will result in an error.
+/// All values below `MIN_PWM` being used as
+/// parameters to `set_target` will result in an
+/// error.
 pub const MIN_PWM: u16 = 992u16;
 
-/// The maximum PWM that can be sent to any channel by the Maestro.
+/// The maximum PWM that can be sent to any
+/// channel by the Maestro.
 ///
-/// All values above `MAX_PWM` being used as parameters to `set_target` will result in an error.
+/// All values above `MAX_PWM` being used as
+/// parameters to `set_target` will result in an
+/// error.
 pub const MAX_PWM: u16 = 2000u16;
 
-/// All available command flags supported by the Pololu-Protocol.
+/// All available command flags supported by the
+/// Pololu-Protocol.
 ///
 /// # TODO
-/// Review existing docs for this enum and add more iff necessary.
+/// Review existing docs for this enum and add
+/// more iff necessary.
 #[allow(non_camel_case_types, unused)]
 #[derive(Debug, Copy, Clone)]
 #[repr(u8)]
@@ -52,14 +61,16 @@ pub(crate) enum CommandFlags {
     GO_HOME = 0xA2u8,
     STOP_SCRIPT = 0xA4u8,
     RESTART_SCRIPT_AT_SUBROUTINE = 0xA7u8,
-    RESTART_SCRIPT_AT_SUBROUTINE_WITH_PARAMETER = 0xA8u8,
+    RESTART_SCRIPT_AT_SUBROUTINE_WITH_PARAMETER =
+        0xA8u8,
     GET_SCRIPT_STATUS = 0xAEu8,
 }
 
 /// All available channels to send commands to.
 ///
 /// # TODO
-/// Review existing docs for this enum and add more iff necessary.
+/// Review existing docs for this enum and add
+/// more iff necessary.
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone)]
 #[repr(u8)]
@@ -85,11 +96,12 @@ pub enum Channels {
 
 /// Available baudrates supported by the Maestro.
 ///
-/// Note that not all baudrates have been specified.
-/// # TODO
+/// Note that not all baudrates have been
+/// specified. # TODO
 /// Add all remaining baudrates to the enum below.
 ///
-/// Review existing docs for this enum and add more iff necessary.
+/// Review existing docs for this enum and add
+/// more iff necessary.
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone)]
 #[repr(u32)]
@@ -104,7 +116,8 @@ pub enum BaudRates {
 /// All available errors throwable by the Maestro.
 ///
 /// # TODO
-/// Review existing docs for this enum and add more iff necessary.
+/// Review existing docs for this enum and add
+/// more iff necessary.
 ///
 /// ADD DOCUMENTATION FOR ALL VARIANTS DOWN BELOW!
 #[allow(non_camel_case_types)]
@@ -123,13 +136,18 @@ pub enum Errors {
 }
 
 impl From<u16> for Errors {
-    /// Converts a raw `u16` into an `Errors` type.
+    /// Converts a raw `u16` into an `Errors`
+    /// type.
     ///
-    /// Given that the underlying `Errors` types are represented by `u16s`, the conversion should not
-    /// result in any undefined or erroneous behaviour.
+    /// Given that the underlying `Errors` types
+    /// are represented by `u16s`, the
+    /// conversion should not result in any
+    /// undefined or erroneous behaviour.
     fn from(data: u16) -> Self {
-        return if (data >= (Errors::SER_SIGNAL_ERR as u16))
-            && (data <= (Errors::SCRIPT_PC_ERR as u16))
+        return if (data
+            >= (Errors::SER_SIGNAL_ERR as u16))
+            && (data
+                <= (Errors::SCRIPT_PC_ERR as u16))
         {
             unsafe { std::mem::transmute(data) }
         } else {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,6 @@
 // This file may not be copied, modified, or
 // distributed except according to those terms.
 
-// external uses
 use std::{
     error::Error as StdError,
     fmt::{
@@ -23,10 +22,6 @@ use rppal::{
     gpio::Error as GpioError,
     uart::Error as UartError,
 };
-
-// internal mods
-
-// internal uses
 
 /// The custom `raestro` error type.
 ///
@@ -85,15 +80,11 @@ pub enum Error {
 impl Error {
     /// Constructs a `std::io::Error` from the
     /// given parameters
-    pub(crate) fn new_io_error<E>(
-        err_kind: IoErrorKind, err_msg: E,
-    ) -> Self
+    pub(crate) fn new_io_error<E>(err_kind: IoErrorKind, err_msg: E) -> Self
     where
         E: Into<Box<dyn StdError + Send + Sync>>,
     {
-        return Error::Io(IoError::new(
-            err_kind, err_msg,
-        ));
+        return Error::Io(IoError::new(err_kind, err_msg));
     }
 }
 
@@ -101,9 +92,7 @@ impl StdError for Error {}
 
 impl Display for Error {
     /// Formatting for `raestro::Error`.
-    fn fmt(
-        &self, f: &mut Formatter<'_>,
-    ) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         return match self {
             Error::Uninitialized => write!(f, "maestro struct is uninitialized; please consider calling .start() on the instance first"),
             Error::InvalidValue(value) => write!(f, "microsec values must be between 992us and 2000us but {}us was used", value),
@@ -117,9 +106,7 @@ impl Display for Error {
 impl From<IoError> for Error {
     /// Wraps a `std::io::Error` in the
     /// `raestro::Error::Io` variant.
-    fn from(io_error: IoError) -> Self {
-        return Self::Io(io_error);
-    }
+    fn from(io_error: IoError) -> Self { return Self::Io(io_error); }
 }
 
 impl From<UartError> for Error {
@@ -128,23 +115,21 @@ impl From<UartError> for Error {
     /// `raestro::Error`.
     fn from(uart_error: UartError) -> Self {
         return match uart_error {
-            UartError::Io(std_err,) => Error::from(std_err,),
-            UartError::Gpio(gpio_err,) => match gpio_err {
-                GpioError::UnknownModel => {
-                    Error::new_io_error(IoErrorKind::Other, "unknown model",)
-                }
-                GpioError::PinNotAvailable(pin,) => Error::new_io_error(
+            UartError::Io(std_err) => Error::from(std_err),
+            UartError::Gpio(gpio_err) => match gpio_err {
+                GpioError::UnknownModel => Error::new_io_error(IoErrorKind::Other, "unknown model"),
+                GpioError::PinNotAvailable(pin) => Error::new_io_error(
                     IoErrorKind::AddrNotAvailable,
                     format!("pin number {} is not available", pin),
                 ),
-                GpioError::PermissionDenied(err_string,) => Error::new_io_error(
+                GpioError::PermissionDenied(err_string) => Error::new_io_error(
                     IoErrorKind::PermissionDenied,
                     format!("permission denied: {} ", err_string),
                 ),
-                GpioError::Io(error,) => Error::from(error,),
-                GpioError::ThreadPanic => Error::new_io_error(IoErrorKind::Other, "thread panic",),
+                GpioError::Io(error) => Error::from(error),
+                GpioError::ThreadPanic => Error::new_io_error(IoErrorKind::Other, "thread panic"),
             },
-            UartError::InvalidValue => Error::new_io_error(IoErrorKind::Other, "invalid value",),
+            UartError::InvalidValue => Error::new_io_error(IoErrorKind::Other, "invalid value"),
         };
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,15 +2,26 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external uses
-use rppal::{gpio::Error as GpioError, uart::Error as UartError};
 use std::{
     error::Error as StdError,
-    fmt::{Display, Formatter, Result as FmtResult},
-    io::{Error as IoError, ErrorKind as IoErrorKind},
+    fmt::{
+        Display,
+        Formatter,
+        Result as FmtResult,
+    },
+    io::{
+        Error as IoError,
+        ErrorKind as IoErrorKind,
+    },
+};
+
+use rppal::{
+    gpio::Error as GpioError,
+    uart::Error as UartError,
 };
 
 // internal mods
@@ -19,31 +30,44 @@ use std::{
 
 /// The custom `raestro` error type.
 ///
-/// Contains all custom error variants, as well as a wrapper for the `std::io::Error` enum.
-/// All `rppal` errors are unwrapped and converted into their underlying `std::io::Error` instances,
-/// and then wrapped in the `Error::Io` variant.
+/// Contains all custom error variants, as well as
+/// a wrapper for the `std::io::Error` enum. All
+/// `rppal` errors are unwrapped and
+/// converted into their underlying
+/// `std::io::Error` instances, and then wrapped
+/// in the `Error::Io` variant.
 #[derive(Debug)]
 pub enum Error {
-    /// The `maestro` instance is in an `uninitialized` state.
+    /// The `maestro` instance is in an
+    /// `uninitialized` state.
     ///
-    /// Consider calling `Maestro::start` with a corresponding baudrate to transition this instance
-    /// into the `initialized` state.
+    /// Consider calling `Maestro::start` with a
+    /// corresponding baudrate to transition
+    /// this instance into the `initialized`
+    /// state.
     Uninitialized,
 
-    /// An invalid value was passed in as a parameter.
+    /// An invalid value was passed in as a
+    /// parameter.
     ///
-    /// Mainly used when an incorrect microsecond target was passed into `set_target`.
+    /// Mainly used when an incorrect microsecond
+    /// target was passed into `set_target`.
     InvalidValue(u16),
 
-    /// Occurs when the expected number of bytes received from the Maestro do not equal `RESPONSE_SIZE`.
+    /// Occurs when the expected number of bytes
+    /// received from the Maestro do not
+    /// equal `RESPONSE_SIZE`.
     ///
-    /// `FaultyRead.0` is the number of bytes actually read.
+    /// `FaultyRead.0` is the number of bytes
+    /// actually read.
     FaultyRead {
         #[allow(missing_docs)]
         actual_count: usize,
     },
 
-    /// Occurs when the expected number of bytes written to the Maestro were incorrect (according to the protocol being sent).
+    /// Occurs when the expected number of bytes
+    /// written to the Maestro were incorrect
+    /// (according to the protocol being sent).
     FaultyWrite {
         #[allow(missing_docs)]
         actual_count: usize,
@@ -52,16 +76,24 @@ pub enum Error {
         expected_count: usize,
     },
 
-    /// Remaining IO errors as encountered by the `rppal` library, or something else.
+    /// Remaining IO errors as encountered by the
+    /// `rppal` library, or something else.
     Io(IoError),
 }
 
 #[doc(hidden)]
 impl Error {
-    /// Constructs a `std::io::Error` from the given parameters
-    pub(crate) fn new_io_error<E>(err_kind: IoErrorKind, err_msg: E) -> Self
-    where E: Into<Box<dyn StdError + Send + Sync>> {
-        return Error::Io(IoError::new(err_kind, err_msg));
+    /// Constructs a `std::io::Error` from the
+    /// given parameters
+    pub(crate) fn new_io_error<E>(
+        err_kind: IoErrorKind, err_msg: E,
+    ) -> Self
+    where
+        E: Into<Box<dyn StdError + Send + Sync>>,
+    {
+        return Error::Io(IoError::new(
+            err_kind, err_msg,
+        ));
     }
 }
 
@@ -69,7 +101,9 @@ impl StdError for Error {}
 
 impl Display for Error {
     /// Formatting for `raestro::Error`.
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    fn fmt(
+        &self, f: &mut Formatter<'_>,
+    ) -> FmtResult {
         return match self {
             Error::Uninitialized => write!(f, "maestro struct is uninitialized; please consider calling .start() on the instance first"),
             Error::InvalidValue(value) => write!(f, "microsec values must be between 992us and 2000us but {}us was used", value),
@@ -81,31 +115,36 @@ impl Display for Error {
 }
 
 impl From<IoError> for Error {
-    /// Wraps a `std::io::Error` in the `raestro::Error::Io` variant.
+    /// Wraps a `std::io::Error` in the
+    /// `raestro::Error::Io` variant.
     fn from(io_error: IoError) -> Self {
         return Self::Io(io_error);
     }
 }
 
 impl From<UartError> for Error {
-    /// Used to convert from an `rppal::uart::Error` type into the `raestro::Error`.
+    /// Used to convert from an
+    /// `rppal::uart::Error` type into the
+    /// `raestro::Error`.
     fn from(uart_error: UartError) -> Self {
         return match uart_error {
-            UartError::Io(std_err) => Error::from(std_err),
-            UartError::Gpio(gpio_err) => match gpio_err {
-                GpioError::UnknownModel => Error::new_io_error(IoErrorKind::Other, "unknown model"),
-                GpioError::PinNotAvailable(pin) => Error::new_io_error(
+            UartError::Io(std_err,) => Error::from(std_err,),
+            UartError::Gpio(gpio_err,) => match gpio_err {
+                GpioError::UnknownModel => {
+                    Error::new_io_error(IoErrorKind::Other, "unknown model",)
+                }
+                GpioError::PinNotAvailable(pin,) => Error::new_io_error(
                     IoErrorKind::AddrNotAvailable,
                     format!("pin number {} is not available", pin),
                 ),
-                GpioError::PermissionDenied(err_string) => Error::new_io_error(
+                GpioError::PermissionDenied(err_string,) => Error::new_io_error(
                     IoErrorKind::PermissionDenied,
                     format!("permission denied: {} ", err_string),
                 ),
-                GpioError::Io(error) => Error::from(error),
-                GpioError::ThreadPanic => Error::new_io_error(IoErrorKind::Other, "thread panic"),
+                GpioError::Io(error,) => Error::from(error,),
+                GpioError::ThreadPanic => Error::new_io_error(IoErrorKind::Other, "thread panic",),
             },
-            UartError::InvalidValue => Error::new_io_error(IoErrorKind::Other, "invalid value"),
+            UartError::InvalidValue => Error::new_io_error(IoErrorKind::Other, "invalid value",),
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,44 +51,41 @@
 //!
 //! let mut m: Maestro = Maestro::new();
 //! m.start(BaudRates::BR_115200).unwrap();
-//! 
+//!
 //! let channel: Channels = Channels::C_0;
-//! 
+//!
 //! let pos_min = 992u16;
 //! let pos_max = 2000u16;
-//! 
+//!
 //! let sleep_time = Duration::from_millis(1000u64);
-//! 
+//!
 //! loop {
 //!     maestro.set_target(channel, pos_min).unwrap();
 //!     thread::sleep(sleep_time);
-//! 
+//!
 //!     maestro.set_target(channel, pos_max).unwrap();
 //!     thread::sleep(sleep_time);
 //! }
 //! ```
 
-/* external crates */
+// external crates
 
-/* external uses */
+// external uses
 
-/* internal mods */
+// internal mods
 pub mod constants;
+mod errors;
 mod maestro;
 pub mod prelude;
-mod errors;
 mod utils;
 #[cfg(test)]
 mod tests {
-    /* external uses */
+    // external uses
 
-    /* internal mods */
+    // internal mods
 
-    /* internal uses */
-    use crate::{
-        maestro::*,
-        constants::*,
-    };
+    // internal uses
+    use crate::{constants::*, maestro::*};
 
     #[test]
     fn init_and_close() -> () {
@@ -98,6 +95,6 @@ mod tests {
     }
 }
 
-/* internal uses */
-pub use maestro::*;
+// internal uses
 pub use errors::*;
+pub use maestro::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,45 +2,80 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 #![warn(missing_docs)]
 #![warn(missing_doc_code_examples)]
 
-//! An interface for the Pololu Micro Maestro 6-Channel Servo Controller Board.
+//! An interface for the Pololu Micro Maestro
+//! 6-Channel Servo Controller Board.
 //!
-//! `raestro` provides an easy-to-use interface to communicate with the 6-Channel Maestro.
+//! `raestro` provides an easy-to-use interface to
+//! communicate with the 6-Channel Maestro.
 //!
 //! # Prelude
-//! Before continuing, please take note of the following points:
-//! * This library is developed specifically for the Raspberry Pi. Builds on different architectures will not be guaranteed to work.
-//! * Please take caution in wiring the Pololu Micro Maestro to the Raspberry Pi. Incorrect wiring may lead to permanent hardware damage.
+//! Before continuing, please take note of the
+//! following points:
+//! * This library is developed specifically for
+//!   the Raspberry Pi. Builds on different
+//!   architectures will not be guaranteed to
+//!   work.
+//! * Please take caution in wiring the Pololu
+//!   Micro Maestro to the Raspberry Pi. Incorrect
+//!   wiring may lead to permanent hardware
+//!   damage.
 //!
 //! # Getting Started
-//! Below are the hardware and software setup processes that must be followed before successfully interacting with the Maestro, as well as trouble-shooting tips.
+//! Below are the hardware and software setup
+//! processes that must be followed before
+//! successfully interacting with the Maestro, as
+//! well as trouble-shooting tips.
 //!
 //! ### Hardware Setup
-//! 1. Connect the power + ground lines from the Raspberry Pi to the Maestro.
-//! 2. Connect the Raspberry Pi's TX and RX pins to the Maestro's RX and TX pins, respectively. Please note the order in which the pins need to be connected (Raspberry Pi's TX connected to Maestro's RX; Raspberry Pi's RX connected to Maestro's TX).
-//! 3. Connect the power lines for the servos (holding the board such that the pins are facing you and are on the right side of the board, these are the 2 pins on the top right). The left one of the pair is the power; the right one is ground.
-//! 4. Connect up to 6 servos on one of the pin-triples available (the backside of the board has more info on each pin-type).
+//! 1. Connect the power + ground lines from the
+//! Raspberry Pi to the Maestro. 2. Connect the
+//! Raspberry Pi's TX and RX pins to the Maestro's
+//! RX and TX pins, respectively. Please note the
+//! order in which the pins need to be connected
+//! (Raspberry Pi's TX connected to Maestro's RX;
+//! Raspberry Pi's RX connected to Maestro's TX).
+//! 3. Connect the power lines for the servos
+//! (holding the board such that the pins are
+//! facing you and are on the right side of the
+//! board, these are the 2 pins on the top right).
+//! The left one of the pair is the power; the
+//! right one is ground. 4. Connect up to 6 servos
+//! on one of the pin-triples available (the
+//! backside of the board has more info on each
+//! pin-type).
 //!
 //! ### Software Setup
 //! The Rust crate [rppal](https://crates.io/crates/rppal) provides user-level APIs for protocols such as `PWM`, `I2C`, and `UART`. In order to configure `UART` for the Raspberry Pi, do the following:
-//! 1. Remove `console=serial0,11520` from `/boot/cmdline.txt`
-//! 2. Disable the Bluetooth by:
-//!     * Adding `dtoverlay=pi3-disable-bt` to `/boot/config.txt`
-//!         * For the Raspberry Pi 4 models, add `dtoverlay=disable-bt` instead
-//!         * Once this is done, reboot the Raspberry Pi (by powering it off and then on again)
-//!     * Running the command `sudo systemctl disable hciuart`
+//! 1. Remove `console=serial0,11520` from
+//! `/boot/cmdline.txt` 2. Disable the Bluetooth
+//! by:
+//!     * Adding `dtoverlay=pi3-disable-bt` to
+//!       `/boot/config.txt`
+//!         * For the Raspberry Pi 4 models, add
+//!           `dtoverlay=disable-bt` instead
+//!         * Once this is done, reboot the
+//!           Raspberry Pi (by powering it off and
+//!           then on again)
+//!     * Running the command `sudo systemctl
+//!       disable hciuart`
 //!
 //! ### Trouble-shooting
-//! If permission denied errors are being observed, please inspect your user's permissions. More specifically, your user must be added to group `dialout`.
-//! If `cargo build` or `cargo test` do not work because of the `rppal` dependency, check the `rppal` documentations on how to set up `UART`. The link is [here](https://docs.rs/rppal/0.11.3/rppal/uart/index.html).
+//! If permission denied errors are being
+//! observed, please inspect your user's
+//! permissions. More specifically, your user must
+//! be added to group `dialout`. If `cargo build` or `cargo test` do not work because of the `rppal` dependency, check the `rppal` documentations on how to set up `UART`. The link is [here](https://docs.rs/rppal/0.11.3/rppal/uart/index.html).
 //!
 //! # Example Usage
-//! Below are included some simple examples on how to instantiate and start a ['maestro'] instance, as well as how to send some commands to the Micro Maestro 6-Channel Servo Board.
+//! Below are included some simple examples on how
+//! to instantiate and start a ['maestro']
+//! instance, as well as how to send some commands
+//! to the Micro Maestro 6-Channel Servo Board.
 //!
 //! ```
 //! use std::{
@@ -85,12 +120,17 @@ mod tests {
     // internal mods
 
     // internal uses
-    use crate::{constants::*, maestro::*};
+    use crate::{
+        constants::*,
+        maestro::*,
+    };
 
     #[test]
     fn init_and_close() -> () {
         let mut maestro: Maestro = Maestro::new();
-        maestro.start(BaudRates::BR_115200).unwrap();
+        maestro
+            .start(BaudRates::BR_115200)
+            .unwrap();
         maestro.close();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,11 +103,6 @@
 //! }
 //! ```
 
-// external crates
-
-// external uses
-
-// internal mods
 pub mod constants;
 mod errors;
 mod maestro;
@@ -128,9 +123,7 @@ mod tests {
     #[test]
     fn init_and_close() -> () {
         let mut maestro: Maestro = Maestro::new();
-        maestro
-            .start(BaudRates::BR_115200)
-            .unwrap();
+        maestro.start(BaudRates::BR_115200).unwrap();
         maestro.close();
     }
 }

--- a/src/maestro.rs
+++ b/src/maestro.rs
@@ -5,28 +5,14 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external uses */
-use std::{
-    time::Duration,
-    boxed::Box,
-    result::Result as StdResult,
-};
-use rppal::{
-    uart::{
-        Parity,
-        Uart,
-        Result as RppalResult,
-    },
-};
+// external uses
+use rppal::uart::{Parity, Result as RppalResult, Uart};
+use std::{boxed::Box, result::Result as StdResult, time::Duration};
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
-use crate::{
-    utils::*,
-    constants::*,
-    errors::*,
-};
+// internal uses
+use crate::{constants::*, errors::*, utils::*};
 
 /// Public result type.
 ///
@@ -80,12 +66,8 @@ impl Maestro {
     /// In the case of this failure, this instance will be closed and will be transitioned *back* into the `uninitialized` state.
     /// This is done to prevent any leakage of `maestro` instances into the `invalid` state.
     pub fn start(self: &mut Self, baud_rate: BaudRates) -> Result<()> {
-        let uart_result: RppalResult<Uart> = Uart::new(
-            baud_rate as u32,
-            Parity::None,
-            DATA_BITS,
-            STOP_BITS,
-        );
+        let uart_result: RppalResult<Uart> =
+            Uart::new(baud_rate as u32, Parity::None, DATA_BITS, STOP_BITS);
 
         return uart_result
             .and_then(|uart| {
@@ -93,18 +75,16 @@ impl Maestro {
                 self.read_buf = Some(Box::new([0u8; BUFFER_SIZE]));
                 self.write_buf = Some(Box::new([0u8; BUFFER_SIZE]));
 
-                return self.uart
+                return self
+                    .uart
                     .as_mut()
                     .unwrap()
                     .as_mut()
                     .set_read_mode(RESPONSE_SIZE, DEFAULT_BLOCKING_DURATION);
             })
             .map(|()| {
-                let buf = self.write_buf
-                    .as_mut()
-                    .unwrap()
-                    .as_mut();
-                
+                let buf = self.write_buf.as_mut().unwrap().as_mut();
+
                 buf[0usize] = SYNC as u8;
                 buf[1usize] = DEVICE_NUMBER as u8;
             })
@@ -136,7 +116,8 @@ impl Maestro {
     ///
     /// Returns an error if the `maestro` instance has not been initialized by calling `Maestro::start()`.
     pub fn set_block_duration(self: &mut Self, duration: Duration) -> Result<()> {
-        return self.uart
+        return self
+            .uart
             .as_mut()
             .ok_or(Error::Uninitialized)
             .and_then(|uart| {
@@ -156,7 +137,6 @@ impl Maestro {
 /// More information on the Pololu-Protocol can be found at the official Pololu Micro Maestro documentation pages, available [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf).
 /// Information on the available serial commands, as well as the specific protocols officially supported (for each type of Maestro), is available in section 5.e.
 impl Maestro {
-
     /// Sets the target of the servo motor at the given channel with the given microseconds.
     ///
     /// Microsecond ranges can only be between `992microsecs` and `2000microsecs`.
@@ -178,9 +158,9 @@ impl Maestro {
         } else {
             Err(Error::InvalidValue(microsec))
         }
-            .and_then(move |payload| {
-                self.write_channel_and_payload(CommandFlags::SET_TARGET, channel, payload)
-            });
+        .and_then(move |payload| {
+            self.write_channel_and_payload(CommandFlags::SET_TARGET, channel, payload)
+        });
     }
 
     /// Sets the rotational speed of the servo motor at the given channel with the given speed.
@@ -221,7 +201,11 @@ impl Maestro {
     /// # TODO:
     /// Check if the Maestro actually rejects the request or just doesn't move if `0u8` is sent as the acceleration.
     pub fn set_acceleration(self: &mut Self, channel: Channels, acceleration: u8) -> Result<()> {
-        return self.write_channel_and_payload(CommandFlags::SET_ACCELERATION, channel, acceleration as u16);
+        return self.write_channel_and_payload(
+            CommandFlags::SET_ACCELERATION,
+            channel,
+            acceleration as u16,
+        );
     }
 
     /// Sends all servos to home position.
@@ -328,7 +312,6 @@ impl Maestro {
 /// Before calling these methods, please ensure that `self.start()` has been called. This can easily be checked by ensuring that
 /// `self.uart`, `read_buf`, and `write_buf` are the Some(_) variants.
 impl Maestro {
-
     /// Reads the given number of bytes into `self.read_buf`.
     ///
     /// Please note that the `self.uart.read` method is being utilized to send the commands over `UART`.
@@ -344,18 +327,16 @@ impl Maestro {
         if length > BUFFER_SIZE {
             panic!();
         }
-        
-        let slice = &mut self.read_buf
-            .as_mut()
-            .unwrap()
-            .as_mut()[0usize..length];
 
-        return self.uart
+        let slice = &mut self.read_buf.as_mut().unwrap().as_mut()[0usize..length];
+
+        return self
+            .uart
             .as_mut()
             .unwrap()
             .read(slice)
             .map_err(|rppal_err| Error::from(rppal_err))
-            .and_then(|bytes_read|
+            .and_then(|bytes_read| {
                 if bytes_read == length {
                     Ok(())
                 } else {
@@ -363,7 +344,7 @@ impl Maestro {
                         actual_count: bytes_read,
                     })
                 }
-            );
+            });
     }
 
     /// Writes the given number of bytes over to the Maestro.
@@ -378,21 +359,19 @@ impl Maestro {
     /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     /// * `self.uart` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     fn write(self: &mut Self, length: usize) -> Result<()> {
-        if (length < MIN_WRITE_LENGTH) || (length > BUFFER_SIZE)  {
+        if (length < MIN_WRITE_LENGTH) || (length > BUFFER_SIZE) {
             panic!();
         }
 
-        let slice = &self.write_buf
-            .as_mut()
-            .unwrap()
-            .as_mut()[0usize..length];
+        let slice = &self.write_buf.as_mut().unwrap().as_mut()[0usize..length];
 
-        return self.uart
+        return self
+            .uart
             .as_mut()
             .unwrap()
             .write(slice)
             .map_err(|rppal_err| Error::from(rppal_err))
-            .and_then(|bytes_written|
+            .and_then(|bytes_written| {
                 if bytes_written == length {
                     Ok(())
                 } else {
@@ -401,7 +380,7 @@ impl Maestro {
                         expected_count: length,
                     })
                 }
-            );
+            });
     }
 
     /// Writes the given arguments into the appropriate place in `self.write_buf`.
@@ -414,20 +393,14 @@ impl Maestro {
     /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     #[inline]
     fn write_channel_and_payload(
-        self: &mut Self,
-        command_flag: CommandFlags,
-        channel: Channels,
-        microsec: u16,
+        self: &mut Self, command_flag: CommandFlags, channel: Channels, microsec: u16,
     ) -> Result<()> {
         let length_to_write = 6usize;
 
         let command = mask_byte(command_flag as u8);
         let (lower, upper) = microsec_to_target(microsec);
 
-        let buffer = self.write_buf
-            .as_mut()
-            .unwrap()
-            .as_mut();
+        let buffer = self.write_buf.as_mut().unwrap().as_mut();
 
         buffer[2usize] = command;
         buffer[3usize] = channel as u8;
@@ -446,19 +419,12 @@ impl Maestro {
     /// Panics if:
     /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     #[inline]
-    fn write_channel(
-        self: &mut Self,
-        command_flag: CommandFlags,
-        channel: Channels,
-    ) -> Result<()> {
+    fn write_channel(self: &mut Self, command_flag: CommandFlags, channel: Channels) -> Result<()> {
         let length_to_write = 4usize;
 
         let command = mask_byte(command_flag as u8);
 
-        let buffer = self.write_buf
-            .as_mut()
-            .unwrap()
-            .as_mut();
+        let buffer = self.write_buf.as_mut().unwrap().as_mut();
 
         buffer[2usize] = command;
         buffer[3usize] = channel as u8;
@@ -475,18 +441,12 @@ impl Maestro {
     /// Panics if:
     /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     #[inline]
-    fn write_command(
-        self: &mut Self,
-        command_flag: CommandFlags,
-    ) -> Result<()> {
+    fn write_command(self: &mut Self, command_flag: CommandFlags) -> Result<()> {
         let length_to_write = 3usize;
 
         let command = mask_byte(command_flag as u8);
 
-        let buffer = self.write_buf
-            .as_mut()
-            .unwrap()
-            .as_mut();
+        let buffer = self.write_buf.as_mut().unwrap().as_mut();
 
         buffer[2usize] = command;
 
@@ -501,10 +461,7 @@ impl Maestro {
     /// * `self.read_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
     #[inline]
     fn prepare_data_from_buffer(self: &mut Self) -> u16 {
-        let buf = self.read_buf
-            .as_mut()
-            .unwrap()
-            .as_mut();
+        let buf = self.read_buf.as_mut().unwrap().as_mut();
 
         let data: u16 = ((buf[1usize] as u16) << 8usize) | (buf[0usize] as u16);
 
@@ -519,6 +476,6 @@ impl Maestro {
     fn read_after_writing(self: &mut Self, write_result: Result<()>) -> Result<u16> {
         return write_result
             .and_then(|()| self.read(RESPONSE_SIZE as usize))
-            .map(|()| self.prepare_data_from_buffer())
+            .map(|()| self.prepare_data_from_buffer());
     }
 }

--- a/src/maestro.rs
+++ b/src/maestro.rs
@@ -2,31 +2,49 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
-// external uses
-use rppal::uart::{Parity, Result as RppalResult, Uart};
-use std::{boxed::Box, result::Result as StdResult, time::Duration};
+use std::{
+    boxed::Box,
+    result::Result as StdResult,
+    time::Duration,
+};
 
-// internal mods
+use rppal::uart::{
+    Parity,
+    Result as RppalResult,
+    Uart,
+};
 
-// internal uses
-use crate::{constants::*, errors::*, utils::*};
+use crate::{
+    constants::*,
+    errors::*,
+    utils::*,
+};
 
 /// Public result type.
 ///
-/// Expands to `std::result::Result<T, raestro::error::Error>`.
+/// Expands to `std::result::Result<T,
+/// raestro::error::Error>`.
 pub type Result<T> = StdResult<T, Error>;
 
-const DEFAULT_BLOCKING_DURATION: Duration = Duration::from_secs(2u64);
+const DEFAULT_BLOCKING_DURATION: Duration =
+    Duration::from_secs(2u64);
 const BUFFER_SIZE: usize = 6usize;
 
-/// The main wrapper around the Maestro communications interface.
+/// The main wrapper around the Maestro
+/// communications interface.
 ///
-/// The `impl` blocks for this struct are split into three sections, two of which are included below, with the remaining being private and hidden from documentation:
-/// 1. Basic public APIs; contains the standard APIs to create, initailize, and close a Maestro instance
-/// 2. Pololu Micro Maestro Protocols; all the protocols supported by the Maestro, sendable over the `UART` pins on the Raspberry Pi
+/// The `impl` blocks for this struct are split
+/// into three sections, two of which are included
+/// below, with the remaining being private
+/// and hidden from documentation: 1. Basic public
+/// APIs; contains the standard APIs to create,
+/// initailize, and close a Maestro instance
+/// 2. Pololu Micro Maestro Protocols; all the
+/// protocols supported by the Maestro, sendable
+/// over the `UART` pins on the Raspberry Pi
 #[derive(Debug)]
 pub struct Maestro {
     uart: Option<Box<Uart>>,
@@ -35,21 +53,34 @@ pub struct Maestro {
 }
 
 /// # Basic public APIs
-/// This section contains all the APIs required to get a `maestro` instance up and running.
+/// This section contains all the APIs required to
+/// get a `maestro` instance up and running.
 ///
 /// ## Definitions
-/// An `initialized` `maestro` instance is defined as an instance in which struct fields are the `Some(_)` variant.
+/// An `initialized` `maestro` instance is defined
+/// as an instance in which struct fields are the
+/// `Some(_)` variant.
 ///
-/// An `uninitialized` `maestro` instance is an instance in which all fields are the `None` variant.
+/// An `uninitialized` `maestro` instance is an
+/// instance in which all fields are the `None`
+/// variant.
 ///
-/// An `invalid` `maestro` instance is an instance which does not fit the above definitions.
+/// An `invalid` `maestro` instance is an instance
+/// which does not fit the above definitions.
 ///
-/// All valid `maestro` instances must either `uninitialized` or `initialized`. An `invalid` `maestro` instance will result in undefined behaviour.
-/// All methods below are proved to either only transition a `maestro` instance to `uninitialized` and `initialized` states only.
-/// Therefore, `invalid` states are impossible to reach.
-/// This is an invariant which must (and will) be guaranteed for all provided APIs.
+/// All valid `maestro` instances must either
+/// `uninitialized` or `initialized`. An `invalid`
+/// `maestro` instance will result in
+/// undefined behaviour. All methods below are
+/// proved to either only transition a `maestro`
+/// instance to `uninitialized` and `initialized`
+/// states only. Therefore, `invalid` states are
+/// impossible to reach. This is an invariant
+/// which must (and will) be guaranteed for all
+/// provided APIs.
 impl Maestro {
-    /// Creates a new `maestro` instance in the `uninitialized` state.
+    /// Creates a new `maestro` instance in the
+    /// `uninitialized` state.
     pub fn new() -> Self {
         return Maestro {
             uart: None,
@@ -58,32 +89,57 @@ impl Maestro {
         };
     }
 
-    /// Transitions the given `maestro` instance to the `initialized` state with default configuration values.
+    /// Transitions the given `maestro` instance
+    /// to the `initialized` state with
+    /// default configuration values.
     ///
-    /// Default block duration is set to `2seconds`.
+    /// Default block duration is set to
+    /// `2seconds`.
     ///
-    /// Returns an error if any fields were unable to be initialized.
-    /// In the case of this failure, this instance will be closed and will be transitioned *back* into the `uninitialized` state.
-    /// This is done to prevent any leakage of `maestro` instances into the `invalid` state.
-    pub fn start(self: &mut Self, baud_rate: BaudRates) -> Result<()> {
+    /// Returns an error if any fields were unable
+    /// to be initialized. In the case of this
+    /// failure, this instance will be closed and
+    /// will be transitioned *back* into the
+    /// `uninitialized` state. This is done to
+    /// prevent any leakage of `maestro` instances
+    /// into the `invalid` state.
+    pub fn start(
+        self: &mut Self, baud_rate: BaudRates,
+    ) -> Result<()> {
         let uart_result: RppalResult<Uart> =
-            Uart::new(baud_rate as u32, Parity::None, DATA_BITS, STOP_BITS);
+            Uart::new(
+                baud_rate as u32,
+                Parity::None,
+                DATA_BITS,
+                STOP_BITS,
+            );
 
         return uart_result
             .and_then(|uart| {
                 self.uart = Some(Box::new(uart));
-                self.read_buf = Some(Box::new([0u8; BUFFER_SIZE]));
-                self.write_buf = Some(Box::new([0u8; BUFFER_SIZE]));
+                self.read_buf = Some(Box::new(
+                    [0u8; BUFFER_SIZE],
+                ));
+                self.write_buf = Some(Box::new(
+                    [0u8; BUFFER_SIZE],
+                ));
 
                 return self
                     .uart
                     .as_mut()
                     .unwrap()
                     .as_mut()
-                    .set_read_mode(RESPONSE_SIZE, DEFAULT_BLOCKING_DURATION);
+                    .set_read_mode(
+                        RESPONSE_SIZE,
+                        DEFAULT_BLOCKING_DURATION,
+                    );
             })
             .map(|()| {
-                let buf = self.write_buf.as_mut().unwrap().as_mut();
+                let buf = self
+                    .write_buf
+                    .as_mut()
+                    .unwrap()
+                    .as_mut();
 
                 buf[0usize] = SYNC as u8;
                 buf[1usize] = DEVICE_NUMBER as u8;
@@ -95,52 +151,83 @@ impl Maestro {
             });
     }
 
-    /// Closes the `maestro` instance (i.e., transitions the `maestro` instance *back* into the `uninitialized` state).
+    /// Closes the `maestro` instance (i.e.,
+    /// transitions the `maestro`
+    /// instance *back* into the `uninitialized`
+    /// state).
     ///
-    /// This instance is no longer usable to communicate with the Maestro, unless until `Maestro::start()` is called again.
+    /// This instance is no longer usable to
+    /// communicate with the Maestro, unless
+    /// until `Maestro::start()` is called again.
     pub fn close(self: &mut Self) -> () {
         self.uart = None;
         self.read_buf = None;
         self.write_buf = None;
     }
 
-    /// Configures the block duration to the passed in value.
+    /// Configures the block duration to the
+    /// passed in value.
     ///
-    /// Default block duration is set to `2seconds`.
+    /// Default block duration is set to
+    /// `2seconds`.
     ///
     /// # Note
-    /// Reading from the Maestro is implemented as a *blocking* read.
-    /// Given that the Maestro only writes back when requested to do so, and that writes coming from the Maestro happen immediately after requests sent to it,
-    /// (implying that waiting times are minimal), a blocking read is sufficient (and probably more efficient than implementing
-    /// any sort of asynchronous functionality).
+    /// Reading from the Maestro is implemented as
+    /// a *blocking* read. Given that the
+    /// Maestro only writes back when requested to
+    /// do so, and that writes coming from the
+    /// Maestro happen immediately
+    /// after requests sent to it, (implying that
+    /// waiting times are minimal), a blocking
+    /// read is sufficient (and probably more
+    /// efficient than implementing any sort of
+    /// asynchronous functionality).
     ///
-    /// Returns an error if the `maestro` instance has not been initialized by calling `Maestro::start()`.
-    pub fn set_block_duration(self: &mut Self, duration: Duration) -> Result<()> {
+    /// Returns an error if the `maestro` instance
+    /// has not been initialized by calling
+    /// `Maestro::start()`.
+    pub fn set_block_duration(
+        self: &mut Self, duration: Duration,
+    ) -> Result<()> {
         return self
             .uart
             .as_mut()
             .ok_or(Error::Uninitialized)
             .and_then(|uart| {
                 return uart
-                    .set_read_mode(RESPONSE_SIZE, duration)
-                    .map_err(|rppal_err| Error::from(rppal_err));
+                    .set_read_mode(
+                        RESPONSE_SIZE,
+                        duration,
+                    )
+                    .map_err(|rppal_err| {
+                        Error::from(rppal_err)
+                    });
             });
     }
 }
 
 /// # Pololu Micro Maestro Protocols
 ///
-/// These protocols are officially supported by the Pololu Micro Maestro 6-Channel.
+/// These protocols are officially supported by
+/// the Pololu Micro Maestro 6-Channel.
 ///
-/// For interacting with the Pololu, the official "Pololu-Protocol" is being utilized.
+/// For interacting with the Pololu, the official
+/// "Pololu-Protocol" is being utilized.
 ///
 /// More information on the Pololu-Protocol can be found at the official Pololu Micro Maestro documentation pages, available [here](https://www.pololu.com/docs/pdf/0J40/maestro.pdf).
-/// Information on the available serial commands, as well as the specific protocols officially supported (for each type of Maestro), is available in section 5.e.
+/// Information on the available serial commands,
+/// as well as the specific protocols officially
+/// supported (for each type of Maestro), is
+/// available in section 5.e.
 impl Maestro {
-    /// Sets the target of the servo motor at the given channel with the given microseconds.
+    /// Sets the target of the servo motor at the
+    /// given channel with
+    /// the given microseconds.
     ///
-    /// Microsecond ranges can only be between `992microsecs` and `2000microsecs`.
-    /// Any values outside of this range will return an error.
+    /// Microsecond ranges can only be between
+    /// `992microsecs` and `2000microsecs`.
+    /// Any values outside of this range will
+    /// return an error.
     ///
     /// # Example Usage
     /// ```
@@ -152,18 +239,29 @@ impl Maestro {
     ///
     /// m.set_target(channel, microsec);
     /// ```
-    pub fn set_target(self: &mut Self, channel: Channels, microsec: u16) -> Result<()> {
-        return if MIN_PWM <= microsec && microsec <= MAX_PWM {
+    pub fn set_target(
+        self: &mut Self, channel: Channels,
+        microsec: u16,
+    ) -> Result<()> {
+        return if MIN_PWM <= microsec
+            && microsec <= MAX_PWM
+        {
             Ok(microsec << DATA_MULTIPLIER)
         } else {
             Err(Error::InvalidValue(microsec))
         }
         .and_then(move |payload| {
-            self.write_channel_and_payload(CommandFlags::SET_TARGET, channel, payload)
+            self.write_channel_and_payload(
+                CommandFlags::SET_TARGET,
+                channel,
+                payload,
+            )
         });
     }
 
-    /// Sets the rotational speed of the servo motor at the given channel with the given speed.
+    /// Sets the rotational speed of the servo
+    /// motor at the given channel with the
+    /// given speed.
     ///
     /// # Example Usage
     /// ```
@@ -178,14 +276,25 @@ impl Maestro {
     ///
     /// # TODO
     /// Search up the max speed value allowable.
-    pub fn set_speed(self: &mut Self, channel: Channels, speed: u16) -> Result<()> {
-        return self.write_channel_and_payload(CommandFlags::SET_SPEED, channel, speed);
+    pub fn set_speed(
+        self: &mut Self, channel: Channels,
+        speed: u16,
+    ) -> Result<()> {
+        return self.write_channel_and_payload(
+            CommandFlags::SET_SPEED,
+            channel,
+            speed,
+        );
     }
 
-    /// Sets the rotational acceleration of the servo motor at the given channel with the given value.
+    /// Sets the rotational acceleration of the
+    /// servo motor at the given channel with
+    /// the given value.
     ///
-    /// The acceleration can be any usigned 8-bit integer from `1u8` to `255u8`.
-    /// An acceleration of `0u8` will command the Maestro to reject the request.
+    /// The acceleration can be any usigned 8-bit
+    /// integer from `1u8` to `255u8`. An
+    /// acceleration of `0u8` will command the
+    /// Maestro to reject the request.
     ///
     /// # Example Usage
     /// ```
@@ -199,18 +308,24 @@ impl Maestro {
     /// ```
     ///
     /// # TODO:
-    /// Check if the Maestro actually rejects the request or just doesn't move if `0u8` is sent as the acceleration.
-    pub fn set_acceleration(self: &mut Self, channel: Channels, acceleration: u8) -> Result<()> {
+    /// Check if the Maestro actually rejects the
+    /// request or just doesn't move if `0u8`
+    /// is sent as the acceleration.
+    pub fn set_acceleration(
+        self: &mut Self, channel: Channels,
+        acceleration: u8,
+    ) -> Result<()> {
         return self.write_channel_and_payload(
             CommandFlags::SET_ACCELERATION,
             channel,
-            acceleration as u16,
+            acceleration.into(),
         );
     }
 
     /// Sends all servos to home position.
     ///
-    /// Home position is defined as `992microsecs`.
+    /// Home position is defined as
+    /// `992microsecs`.
     ///
     /// # Example Usage
     /// ```
@@ -219,11 +334,16 @@ impl Maestro {
     ///
     /// m.go_home();
     /// ```
-    pub fn go_home(self: &mut Self) -> Result<()> {
-        return self.write_command(CommandFlags::GO_HOME);
+    pub fn go_home(
+        self: &mut Self,
+    ) -> Result<()> {
+        return self.write_command(
+            CommandFlags::GO_HOME,
+        );
     }
 
-    /// Stops all requested actions sent to the Maestro to be stopped immediately.
+    /// Stops all requested actions sent to the
+    /// Maestro to be stopped immediately.
     ///
     /// # Example Usage
     /// ```
@@ -234,26 +354,51 @@ impl Maestro {
     /// ```
     ///
     /// # TODO
-    /// Find out how the Maestro implements `stop_script`.
-    pub fn stop_script(self: &mut Self) -> Result<()> {
-        return self.write_command(CommandFlags::STOP_SCRIPT);
+    /// Find out how the Maestro implements
+    /// `stop_script`.
+    pub fn stop_script(
+        self: &mut Self,
+    ) -> Result<()> {
+        return self.write_command(
+            CommandFlags::STOP_SCRIPT,
+        );
     }
 
-    /// Gets the `PWM` signal being broadcasted to the servo at the given channel.
+    /// Gets the `PWM` signal being broadcasted to
+    /// the servo at the given channel.
     ///
     /// # Important
-    /// In order to rotate the servos, the Maestro sends a PWM signal over the corresponding channel.
-    /// This is, in essence, what is happening when `set_target` is called.
-    /// However, this signal can still be sent even if a servo motor is not connected to the pins; the only difference
-    /// here being that no servo is connected to execute the rotation, but the signal is *still sent*, regardless.
+    /// In order to rotate the servos, the Maestro
+    /// sends a PWM signal
+    /// over the corresponding channel. This is,
+    /// in essence, what is happening when
+    /// `set_target` is called. However, this
+    /// signal can still be sent even if a servo
+    /// motor is not connected to the pins;
+    /// the only difference here being that no
+    /// servo is connected to execute the
+    /// rotation, but the signal
+    /// is *still sent*, regardless.
     ///
-    /// The `get_position` request will only return the `PWM` that is being broadcasted on the channel.
-    /// Using this method will NOT help you in determining servo failures, incorrect servo positions, etc.
-    /// This method will *only* return the `PWM` that is being broadcasted on the given channel.
+    /// The `get_position` request will only
+    /// return the `PWM` that is
+    /// being broadcasted on the channel. Using
+    /// this method will NOT help you in
+    /// determining servo failures, incorrect
+    /// servo positions, etc. This method will
+    /// *only* return the `PWM` that is being
+    /// broadcasted on the given channel.
     ///
-    /// The Maestro, in and of itself, cannot possibly know if a servo is or is not at the location that was encoded
-    /// in the request (i.e., if the servo failed half-way through exectution). As such, `raestro` cannot support this functionality either.
-    /// If this functionality is required for your project, you will need to develop additional hardware.
+    /// The Maestro, in and of itself, cannot
+    /// possibly know if a servo is or is not
+    /// at the location that was encoded
+    /// in the request (i.e., if the servo failed
+    /// half-way through exectution). As such,
+    /// `raestro` cannot support this
+    /// functionality either. If this
+    /// functionality is required
+    /// for your project, you will need to develop
+    /// additional hardware.
     ///
     /// # Example Usage
     /// ```
@@ -269,20 +414,32 @@ impl Maestro {
     ///
     /// assert_eq!(position, actual_position);
     /// ```
-    pub fn get_position(self: &mut Self, channel: Channels) -> Result<u16> {
-        let write_result = self.write_channel(CommandFlags::GET_POSITION, channel);
+    pub fn get_position(
+        self: &mut Self, channel: Channels,
+    ) -> Result<u16> {
+        let write_result = self.write_channel(
+            CommandFlags::GET_POSITION,
+            channel,
+        );
 
         return self
             .read_after_writing(write_result)
-            .map(move |result| result >> DATA_MULTIPLIER);
+            .map(move |result| {
+                result >> DATA_MULTIPLIER
+            });
     }
 
-    /// Gets any errors encountered by the Maestro during execution.
+    /// Gets any errors encountered by the Maestro
+    /// during execution.
     ///
     /// # Important
-    /// This method will *not* inform you of any failures with the servo hardware.
-    /// The Maestro, in and of itself, is not capable of determining external hardware malfunctions.
-    /// If your project requires this feature, you will need to develop additional hardware to implement it.
+    /// This method will *not* inform you of any
+    /// failures with the servo hardware. The
+    /// Maestro, in and of itself, is not
+    /// capable of determining external hardware
+    /// malfunctions. If your project requires
+    /// this feature, you will need to develop
+    /// additional hardware to implement it.
     ///
     /// # Example Usage
     /// ```
@@ -291,8 +448,12 @@ impl Maestro {
     ///
     /// let errors = m.get_errors().unwrap();
     /// ```
-    pub fn get_errors(self: &mut Self) -> Result<Errors> {
-        let write_result = self.write_command(CommandFlags::GET_ERRORS);
+    pub fn get_errors(
+        self: &mut Self,
+    ) -> Result<Errors> {
+        let write_result = self.write_command(
+            CommandFlags::GET_ERRORS,
+        );
 
         return self
             .read_after_writing(write_result)
@@ -304,38 +465,64 @@ impl Maestro {
 ///
 /// All hidden from public documentation.
 ///
-/// Provide basic utilities and abstracted functionality to the rest of the program
+/// Provide basic utilities and abstracted
+/// functionality to the rest of the program
 ///
-/// Please note that all methods in this `impl` block operate on the assumption that 'self.start()' has been called.
-/// Since these are private methods, calls to these methods can only be made by `Maestro` methods, *NOT* public callers.
-/// Therefore, operating under the assumptions that `self.start()` has been called and panicking otherwise is appropriate.
-/// Before calling these methods, please ensure that `self.start()` has been called. This can easily be checked by ensuring that
-/// `self.uart`, `read_buf`, and `write_buf` are the Some(_) variants.
+/// Please note that all methods in this `impl`
+/// block operate on the assumption that
+/// 'self.start()' has been called. Since these
+/// are private methods, calls to these methods
+/// can only be made by `Maestro` methods, *NOT*
+/// public callers. Therefore, operating under the
+/// assumptions that `self.start()` has been
+/// called and panicking otherwise is appropriate.
+/// Before calling these methods, please ensure
+/// that `self.start()` has been called. This can
+/// easily be checked by ensuring that
+/// `self.uart`, `read_buf`, and `write_buf` are
+/// the Some(_) variants.
 impl Maestro {
-    /// Reads the given number of bytes into `self.read_buf`.
+    /// Reads the given number of bytes into
+    /// `self.read_buf`.
     ///
-    /// Please note that the `self.uart.read` method is being utilized to send the commands over `UART`.
-    /// This command operates on a blocking read.
-    /// Blocking duration is default set to `DEFAULT_BLOCKING_DURATION`.
+    /// Please note that the `self.uart.read`
+    /// method is being utilized to send the
+    /// commands over `UART`. This command
+    /// operates on a blocking read. Blocking
+    /// duration is default set to
+    /// `DEFAULT_BLOCKING_DURATION`.
     ///
     /// # Panics
     /// Panics if:
-    /// * `length` is strictly greater than the `BUFFER_SIZE`
-    /// * `self.read_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
-    /// * `self.uart` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
-    fn read(self: &mut Self, length: usize) -> Result<()> {
+    /// * `length` is strictly greater than the
+    ///   `BUFFER_SIZE`
+    /// * `self.read_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
+    /// * `self.uart` array is the `None` variant;
+    ///   in this case, the `self` instance has
+    ///   NOT been initialized.
+    fn read(
+        self: &mut Self, length: usize,
+    ) -> Result<()> {
         if length > BUFFER_SIZE {
             panic!();
         }
 
-        let slice = &mut self.read_buf.as_mut().unwrap().as_mut()[0usize..length];
+        let slice = &mut self
+            .read_buf
+            .as_mut()
+            .unwrap()
+            .as_mut()[0usize..length];
 
         return self
             .uart
             .as_mut()
             .unwrap()
             .read(slice)
-            .map_err(|rppal_err| Error::from(rppal_err))
+            .map_err(|rppal_err| {
+                Error::from(rppal_err)
+            })
             .and_then(|bytes_read| {
                 if bytes_read == length {
                     Ok(())
@@ -347,60 +534,95 @@ impl Maestro {
             });
     }
 
-    /// Writes the given number of bytes over to the Maestro.
+    /// Writes the given number of bytes over to
+    /// the Maestro.
     ///
-    /// The bytes that are being written are located in the `self.write_buf` array.
-    /// This is the method that actually calls `self.uart.write`. Other methods in this `impl` block just write to `self.write_buf`, but
-    /// do not actually send data over the `UART` pins.
+    /// The bytes that are being written are
+    /// located in the `self.write_buf` array.
+    /// This is the method that actually calls
+    /// `self.uart.write`. Other methods in this
+    /// `impl` block just write to
+    /// `self.write_buf`, but do not actually send
+    /// data over the `UART` pins.
     ///
     /// # Panics
     /// Panics if:
-    /// * `length` is strictly greater than the `BUFFER_SIZE`
-    /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
-    /// * `self.uart` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
-    fn write(self: &mut Self, length: usize) -> Result<()> {
-        if (length < MIN_WRITE_LENGTH) || (length > BUFFER_SIZE) {
+    /// * `length` is strictly greater than the
+    ///   `BUFFER_SIZE`
+    /// * `self.write_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
+    /// * `self.uart` array is the `None` variant;
+    ///   in this case, the `self` instance has
+    ///   NOT been initialized.
+    fn write(
+        self: &mut Self, length: usize,
+    ) -> Result<()> {
+        if (length < MIN_WRITE_LENGTH)
+            || (length > BUFFER_SIZE)
+        {
             panic!();
         }
 
-        let slice = &self.write_buf.as_mut().unwrap().as_mut()[0usize..length];
+        let slice = &self
+            .write_buf
+            .as_mut()
+            .unwrap()
+            .as_mut()[0usize..length];
 
         return self
             .uart
             .as_mut()
             .unwrap()
             .write(slice)
-            .map_err(|rppal_err| Error::from(rppal_err))
+            .map_err(|rppal_err| {
+                Error::from(rppal_err)
+            })
             .and_then(|bytes_written| {
                 if bytes_written == length {
                     Ok(())
                 } else {
                     Err(Error::FaultyWrite {
-                        actual_count: bytes_written,
+                        actual_count:
+                            bytes_written,
                         expected_count: length,
                     })
                 }
             });
     }
 
-    /// Writes the given arguments into the appropriate place in `self.write_buf`.
+    /// Writes the given arguments into the
+    /// appropriate place in `self.write_buf`.
     ///
-    /// This method does not actually send the bytes over the `UART` pins. It just writes them into the correct place in the buffer
-    /// and then calls `self.write` while passing in the desired length.
+    /// This method does not actually send the
+    /// bytes over the `UART` pins. It just
+    /// writes them into the correct place in the
+    /// buffer and then calls `self.write`
+    /// while passing in the desired length.
     ///
     /// # Panics
     /// Panics if:
-    /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
+    /// * `self.write_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
     #[inline]
     fn write_channel_and_payload(
-        self: &mut Self, command_flag: CommandFlags, channel: Channels, microsec: u16,
+        self: &mut Self,
+        command_flag: CommandFlags,
+        channel: Channels, microsec: u16,
     ) -> Result<()> {
         let length_to_write = 6usize;
 
-        let command = mask_byte(command_flag as u8);
-        let (lower, upper) = microsec_to_target(microsec);
+        let command =
+            mask_byte(command_flag as u8);
+        let (lower, upper) =
+            microsec_to_target(microsec);
 
-        let buffer = self.write_buf.as_mut().unwrap().as_mut();
+        let buffer = self
+            .write_buf
+            .as_mut()
+            .unwrap()
+            .as_mut();
 
         buffer[2usize] = command;
         buffer[3usize] = channel as u8;
@@ -410,21 +632,36 @@ impl Maestro {
         return self.write(length_to_write);
     }
 
-    /// Writes the given arguments into the appropriate place in `self.write_buf`.
+    /// Writes the given arguments into the
+    /// appropriate place in `self.write_buf`.
     ///
-    /// This method does not actually send the bytes over the `UART` pins. It just writes them into the correct place in the buffer
-    /// and then calls `self.write` while passing in the desired length.
+    /// This method does not actually send the
+    /// bytes over the `UART` pins. It just
+    /// writes them into the correct place in the
+    /// buffer and then calls `self.write`
+    /// while passing in the desired length.
     ///
     /// # Panics
     /// Panics if:
-    /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
+    /// * `self.write_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
     #[inline]
-    fn write_channel(self: &mut Self, command_flag: CommandFlags, channel: Channels) -> Result<()> {
+    fn write_channel(
+        self: &mut Self,
+        command_flag: CommandFlags,
+        channel: Channels,
+    ) -> Result<()> {
         let length_to_write = 4usize;
 
-        let command = mask_byte(command_flag as u8);
+        let command =
+            mask_byte(command_flag as u8);
 
-        let buffer = self.write_buf.as_mut().unwrap().as_mut();
+        let buffer = self
+            .write_buf
+            .as_mut()
+            .unwrap()
+            .as_mut();
 
         buffer[2usize] = command;
         buffer[3usize] = channel as u8;
@@ -432,50 +669,87 @@ impl Maestro {
         return self.write(length_to_write);
     }
 
-    /// Writes the given arguments into the appropriate place in `self.write_buf`.
+    /// Writes the given arguments into the
+    /// appropriate place in `self.write_buf`.
     ///
-    /// This method does not actually send the bytes over the `UART` pins. It just writes them into the correct place in the buffer
-    /// and then calls `self.write` while passing in the desired length.
+    /// This method does not actually send the
+    /// bytes over the `UART` pins. It just
+    /// writes them into the correct place in the
+    /// buffer and then calls `self.write`
+    /// while passing in the desired length.
     ///
     /// # Panics
     /// Panics if:
-    /// * `self.write_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
+    /// * `self.write_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
     #[inline]
-    fn write_command(self: &mut Self, command_flag: CommandFlags) -> Result<()> {
+    fn write_command(
+        self: &mut Self,
+        command_flag: CommandFlags,
+    ) -> Result<()> {
         let length_to_write = 3usize;
 
-        let command = mask_byte(command_flag as u8);
+        let command =
+            mask_byte(command_flag as u8);
 
-        let buffer = self.write_buf.as_mut().unwrap().as_mut();
+        let buffer = self
+            .write_buf
+            .as_mut()
+            .unwrap()
+            .as_mut();
 
         buffer[2usize] = command;
 
         return self.write(length_to_write);
     }
 
-    /// Utility function to take the first two bytes in `self.read_buf` and convert them from Pololu standardized-return-form
-    /// to u16.
+    /// Utility function to take the first two
+    /// bytes in `self.read_buf` and convert
+    /// them from Pololu
+    /// standardized-return-form to u16.
     ///
     /// # Panics
     /// Panics if:
-    /// * `self.read_buf` array is the `None` variant; in this case, the `self` instance has NOT been initialized.
+    /// * `self.read_buf` array is the `None`
+    ///   variant; in this case, the `self`
+    ///   instance has NOT been initialized.
     #[inline]
-    fn prepare_data_from_buffer(self: &mut Self) -> u16 {
-        let buf = self.read_buf.as_mut().unwrap().as_mut();
+    fn prepare_data_from_buffer(
+        self: &mut Self,
+    ) -> u16 {
+        let buf = self
+            .read_buf
+            .as_mut()
+            .unwrap()
+            .as_mut();
 
-        let data: u16 = ((buf[1usize] as u16) << 8usize) | (buf[0usize] as u16);
+        let data: u16 = ((buf[1usize] as u16)
+            << 8usize)
+            | (buf[0usize] as u16);
 
         return data;
     }
 
-    /// Takes the write result and applies immediately calls for a read after.
+    /// Takes the write result and applies
+    /// immediately calls for a read after.
     ///
-    /// Useful abstraction over Pololu protocols that send data back right after a request.
-    /// For example, a request to `get_position` will require first a `write`, and then immediately a `read_after_writing`.
-    /// Therefore, for those types of situations, use this method.
-    fn read_after_writing(self: &mut Self, write_result: Result<()>) -> Result<u16> {
+    /// Useful abstraction over Pololu protocols
+    /// that send data back right after a
+    /// request. For example, a request to
+    /// `get_position` will require first a
+    /// `write`, and then immediately a
+    /// `read_after_writing`. Therefore, for those
+    /// types of situations, use this method.
+    fn read_after_writing(
+        self: &mut Self, write_result: Result<()>,
+    ) -> Result<u16> {
         return write_result
-            .and_then(|()| self.read(RESPONSE_SIZE as usize))
-            .map(|()| self.prepare_data_from_buffer());
+            .and_then(|()| {
+                self.read(RESPONSE_SIZE as usize)
+            })
+            .map(|()| {
+                self.prepare_data_from_buffer()
+            });
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,13 +9,9 @@
 //!
 //! Encapsulates all modules required for general usage of the `raestro` library.
 
-/* external uses */
+// external uses
 
-/* internal mods */
+// internal mods
 
-/* internal uses */
-pub use crate::{
-    maestro::*,
-    constants::*,
-    errors::*,
-};
+// internal uses
+pub use crate::{constants::*, errors::*, maestro::*};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,16 +2,21 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 //! Public convenience exports.
 //!
-//! Encapsulates all modules required for general usage of the `raestro` library.
+//! Encapsulates all modules required for general
+//! usage of the `raestro` library.
 
 // external uses
 
 // internal mods
 
 // internal uses
-pub use crate::{constants::*, errors::*, maestro::*};
+pub use crate::{
+    constants::*,
+    errors::*,
+    maestro::*,
+};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,11 +10,6 @@
 //! Encapsulates all modules required for general
 //! usage of the `raestro` library.
 
-// external uses
-
-// internal mods
-
-// internal uses
 pub use crate::{
     constants::*,
     errors::*,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,65 +5,6 @@
 // This file may not be copied, modified, or
 // distributed except according to those terms.
 
-// external uses
-
-// internal mods
-#[cfg(test)]
-mod tests {
-    // external uses
-
-    // internal mods
-
-    // internal uses
-    use super::*;
-
-    #[test]
-    fn simple_mask_byte_test() -> () {
-        let byte: u8 = 0x00u8;
-        let expected_byte: u8 = 0x00u8;
-
-        assert_eq!(
-            mask_byte(byte),
-            expected_byte
-        );
-    }
-
-    #[test]
-    fn medium_mask_byte_test() -> () {
-        let byte: u8 = 0xffu8;
-        let expected_byte: u8 = 0x7fu8;
-
-        assert_eq!(
-            mask_byte(byte),
-            expected_byte
-        );
-    }
-
-    #[test]
-    fn complex_mask_byte_test() -> () {
-        let byte: u8 = 0xa5u8;
-        let expected_byte: u8 = 0x25u8;
-
-        assert_eq!(
-            mask_byte(byte),
-            expected_byte
-        );
-    }
-
-    #[test]
-    fn simple_short_to_target_test() -> () {
-        let target: u16 = 6000u16;
-        let expected: (u8, u8) = (0x70u8, 0x2eu8);
-
-        assert_eq!(
-            microsec_to_target(target),
-            expected
-        );
-    }
-}
-
-// internal uses
-
 /// Given a `u8`, clears the top bit by applying a
 /// mask to it.
 #[inline]
@@ -87,14 +28,48 @@ pub(crate) fn mask_byte(byte: u8) -> u8 {
 /// # Note
 /// This leaves the top 2 bits unused. This is as
 /// is required by the Pololu-Protocol.
-pub(crate) fn microsec_to_target(
-    microsec: u16,
-) -> (u8, u8) {
+pub(crate) fn microsec_to_target(microsec: u16) -> (u8, u8) {
     let down_shift = 7usize;
 
     let lower = mask_byte(microsec as u8);
-    let upper =
-        mask_byte((microsec >> down_shift) as u8);
+    let upper = mask_byte((microsec >> down_shift) as u8);
 
     return (lower, upper);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_mask_byte_test() -> () {
+        let byte: u8 = 0x00u8;
+        let expected_byte: u8 = 0x00u8;
+
+        assert_eq!(mask_byte(byte), expected_byte);
+    }
+
+    #[test]
+    fn medium_mask_byte_test() -> () {
+        let byte: u8 = 0xffu8;
+        let expected_byte: u8 = 0x7fu8;
+
+        assert_eq!(mask_byte(byte), expected_byte);
+    }
+
+    #[test]
+    fn complex_mask_byte_test() -> () {
+        let byte: u8 = 0xa5u8;
+        let expected_byte: u8 = 0x25u8;
+
+        assert_eq!(mask_byte(byte), expected_byte);
+    }
+
+    #[test]
+    fn simple_short_to_target_test() -> () {
+        let target: u16 = 6000u16;
+        let expected: (u8, u8) = (0x70u8, 0x2eu8);
+
+        assert_eq!(microsec_to_target(target), expected);
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,8 +2,8 @@
 //
 // Licensed under the MIT license
 // <LICENSE.md or https://opensource.org/licenses/MIT>.
-// This file may not be copied, modified, or distributed
-// except according to those terms.
+// This file may not be copied, modified, or
+// distributed except according to those terms.
 
 // external uses
 
@@ -22,7 +22,10 @@ mod tests {
         let byte: u8 = 0x00u8;
         let expected_byte: u8 = 0x00u8;
 
-        assert_eq!(mask_byte(byte), expected_byte);
+        assert_eq!(
+            mask_byte(byte),
+            expected_byte
+        );
     }
 
     #[test]
@@ -30,7 +33,10 @@ mod tests {
         let byte: u8 = 0xffu8;
         let expected_byte: u8 = 0x7fu8;
 
-        assert_eq!(mask_byte(byte), expected_byte);
+        assert_eq!(
+            mask_byte(byte),
+            expected_byte
+        );
     }
 
     #[test]
@@ -38,7 +44,10 @@ mod tests {
         let byte: u8 = 0xa5u8;
         let expected_byte: u8 = 0x25u8;
 
-        assert_eq!(mask_byte(byte), expected_byte);
+        assert_eq!(
+            mask_byte(byte),
+            expected_byte
+        );
     }
 
     #[test]
@@ -46,33 +55,46 @@ mod tests {
         let target: u16 = 6000u16;
         let expected: (u8, u8) = (0x70u8, 0x2eu8);
 
-        assert_eq!(microsec_to_target(target), expected);
+        assert_eq!(
+            microsec_to_target(target),
+            expected
+        );
     }
 }
 
 // internal uses
 
-/// Given a `u8`, clears the top bit by applying a mask to it.
+/// Given a `u8`, clears the top bit by applying a
+/// mask to it.
 #[inline]
 pub(crate) fn mask_byte(byte: u8) -> u8 {
     let top_mask: u8 = 0x7fu8;
     return byte & top_mask;
 }
 
-/// The Pololu-Protocol requires that the `u16` be formatted in a specific manner before embedding it
-/// in the protocol message and sending it over `UART`.
+/// The Pololu-Protocol requires that the `u16` be
+/// formatted in a specific manner before
+/// embedding it in the protocol message and
+/// sending it over `UART`.
 ///
 /// Given a 16-bit integer, execute the following:
-/// 1. take low order bits 0 to 6, pad with a 0 in the 7th position. This is the lower byte.
-/// 2. take upper order bits 7 to 13, shift it down 7 bits, pad with a 0 in the 7th position. This is the higher byte.
+/// 1. take low order bits 0 to 6, pad with a 0 in
+/// the 7th position. This is the lower byte. 2.
+/// take upper order bits 7 to 13, shift it down 7
+/// bits, pad with a 0 in the 7th position. This
+/// is the higher byte.
 ///
 /// # Note
-/// This leaves the top 2 bits unused. This is as is required by the Pololu-Protocol.
-pub(crate) fn microsec_to_target(microsec: u16) -> (u8, u8) {
+/// This leaves the top 2 bits unused. This is as
+/// is required by the Pololu-Protocol.
+pub(crate) fn microsec_to_target(
+    microsec: u16,
+) -> (u8, u8) {
     let down_shift = 7usize;
 
     let lower = mask_byte(microsec as u8);
-    let upper = mask_byte((microsec >> down_shift) as u8);
+    let upper =
+        mask_byte((microsec >> down_shift) as u8);
 
     return (lower, upper);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,16 +5,16 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/* external uses */
+// external uses
 
-/* internal mods */
+// internal mods
 #[cfg(test)]
 mod tests {
-    /* external uses */
+    // external uses
 
-    /* internal mods */
+    // internal mods
 
-    /* internal uses */
+    // internal uses
     use super::*;
 
     #[test]
@@ -50,7 +50,7 @@ mod tests {
     }
 }
 
-/* internal uses */
+// internal uses
 
 /// Given a `u8`, clears the top bit by applying a mask to it.
 #[inline]


### PR DESCRIPTION
formatted using rustfmt
all formatting rules can be found in rustfmt.toml
added stop_script example
fixed implementation of constants::Errors