### PR TITLE
fix doc examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,19 @@ crate-type = ["bin"]        # The crate types to generate.
 required-features = []      # Features required to build this target (N/A for lib).
 
 [[example]]
-name = "set_speed"    # The name of the target.
+name = "set_speed"     # The name of the target.
+test = true            # Is tested by default.
+doctest = false        # Documentation examples are tested by default.
+bench = true           # Is benchmarked by default.
+doc = false            # Is documented by default.
+proc-macro = false     # Set to `true` for a proc-macro library.
+harness = true         # Use libtest harness.
+edition = "2018"       # The edition of the target.
+crate-type = ["bin"]   # The crate types to generate.
+required-features = [] # Features required to build this target (N/A for lib).
+
+[[example]]
+name = "stop_script"   # The name of the target.
 test = true            # Is tested by default.
 doctest = false        # Documentation examples are tested by default.
 bench = true           # Is benchmarked by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! instance, as well as how to send some commands
 //! to the Micro Maestro 6-Channel Servo Board.
 //!
-//! ```
+//! ```ignore
 //! use std::{
 //!     thread,
 //!     time::Duration,
@@ -95,10 +95,10 @@
 //! let sleep_time = Duration::from_millis(1000u64);
 //!
 //! loop {
-//!     maestro.set_target(channel, pos_min).unwrap();
+//!     m.set_target(channel, pos_min).unwrap();
 //!     thread::sleep(sleep_time);
 //!
-//!     maestro.set_target(channel, pos_max).unwrap();
+//!     m.set_target(channel, pos_max).unwrap();
 //!     thread::sleep(sleep_time);
 //! }
 //! ```

--- a/src/maestro.rs
+++ b/src/maestro.rs
@@ -208,13 +208,15 @@ impl Maestro {
     ///
     /// # Example Usage
     /// ```
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
     /// let channel: Channels = Channels::C_0; // can be any arbitrary channel in the Channels enum
-    /// let microsec: u16 = 1234u16; // can be any value between 992u16 and 2000u16
+    /// let microsec = 1234u16; // can be any value between 992u16 and 2000u16
     ///
-    /// m.set_target(channel, microsec);
+    /// m.set_target(channel, microsec).unwrap();
     /// ```
     pub fn set_target(&mut self, channel: Channels, microsec: u16) -> Result<()> {
         return if MIN_PWM <= microsec && microsec <= MAX_PWM {
@@ -233,13 +235,15 @@ impl Maestro {
     ///
     /// # Example Usage
     /// ```
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
     /// let channel: Channels = Channels::C_0; // can be any arbitrary channel in the Channels enum
-    /// let speed: u16 = 10u16;
+    /// let speed = 10u16;
     ///
-    /// m.set_speed(channel, speed);
+    /// m.set_speed(channel, speed).unwrap();
     /// ```
     ///
     /// # TODO
@@ -259,13 +263,15 @@ impl Maestro {
     ///
     /// # Example Usage
     /// ```
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
     /// let channel: Channels = Channels::C_0; // can be any arbitrary channel in the Channels enum
-    /// let acceleration: u16 = 10u16;
+    /// let acceleration = 10u8;
     ///
-    /// m.set_acceleration(channel, acceleration);
+    /// m.set_acceleration(channel, acceleration).unwrap();
     /// ```
     ///
     /// # TODO:
@@ -287,10 +293,12 @@ impl Maestro {
     ///
     /// # Example Usage
     /// ```
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
-    /// m.go_home();
+    /// m.go_home().unwrap();
     /// ```
     pub fn go_home(self: &mut Self) -> Result<()> {
         return self.write_command(CommandFlags::GO_HOME);
@@ -301,10 +309,12 @@ impl Maestro {
     ///
     /// # Example Usage
     /// ```
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
-    /// m.stop_script();
+    /// m.stop_script().unwrap();
     /// ```
     ///
     /// # TODO
@@ -351,12 +361,14 @@ impl Maestro {
     /// additional hardware.
     ///
     /// # Example Usage
-    /// ```
+    /// ```ignore
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
     /// let channel: Channels = Channels::C_0; // can be any arbitrary channel in the Channels enum
-    /// let position: u16 = 1234u16; // can be any value between 992u16 and 2000u16
+    /// let position = 1234u16; // can be any value between 992u16 and 2000u16
     ///
     /// m.set_target(channel, position);
     ///
@@ -385,7 +397,9 @@ impl Maestro {
     /// additional hardware to implement it.
     ///
     /// # Example Usage
-    /// ```
+    /// ```ignore
+    /// use raestro::prelude::*;
+    ///
     /// let mut m = Maestro::new();
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
@@ -405,7 +419,7 @@ impl Maestro {
 /// All hidden from public documentation.
 ///
 /// Provide basic utilities and abstracted
-/// functionality to the rest of the program
+/// functionality to the rest of the program.
 ///
 /// Please note that all methods in this `impl`
 /// block operate on the assumption that


### PR DESCRIPTION
fixed all doc examples such that they compile and run
for some reason, set_speed fails sometimes... not sure why
added stop_script example to Cargo.toml
ignored the doc examples in which reading *back* from the maestro is required
ignored lib doc example since it contains an infinite loop of swivelling back and forth

Signed-off-by: Raunak Bhagat <rabhagat31@gmail.com>