### PR TITLE
add travis build svg to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Raestro - A Rust-flavoured API Interface for the Pololu Micro-Maestro (6-Channel) Servo Controller Board
+[![Build Status](https://travis-ci.com/raunakab/raestro.svg?branch=master)](https://travis-ci.com/github/raunakab/raestro)
 [![crates.io](https://meritbadge.herokuapp.com/raestro)](https://crates.io/crates/raestro)
 [![docs](https://docs.rs/raestro/badge.svg)](https://docs.rs/crate/raestro)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)


### PR DESCRIPTION
started a travis CI instance
added a svg to README

#TODO
add a .travis.yml file

Signed-off-by: Raunak Bhagat <rabhagat31@gmail.com>