### PR TITLE
Edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Note that all dates are in DD/MM/YYYY form.
 * finished documentation for all public modules and exports
 * formatted library using rustfmt (all formatting rules can be found in rustfmt.toml)
 * fixed implementation for raestro::constants::Errors
-	* when an error or errors are encountered, the Maestro returns a 2-byte (u16) integer in which each of the first 9 positions (i.e., bit 0 to bit 8) represent an error
-	* if the bit in position i (where i = 0..=8) is set, then the according error was thrown by the Maestro
-	* previous implementation of constants::Errors assumed that each error had a specific number attached to it (i.e., SER_SIGNAL_ERR was 0, SER_BUFFER_ERR was 1, etc.), which is incorrect
+	* when an error or errors are encountered, the Maestro returns a 2-byte (`u16`) integer in which each of the first 9 positions (i.e., bit 0 to bit 8) represent an error
+	* if the bit in position i (where i = `0..=8`) is set, then the according error was thrown by the Maestro
+	* previous implementation of `constants::Errors` assumed that each error had a specific number attached to it (i.e., `SER\_SIGNAL\_ERR` was `0`, `SER\_BUFFER\_ERR` was `1`, etc.), which is incorrect
+
+### 05/06/2021
+* the underlying `uart` instance was incorrectly configured to wait indefinitely if no bytes were read on the `UART` lines
+* this was updated so that `Maestro::read` would only block for 2 seconds, max  (default configuration)
+* `Maestro::set_target` was updated to take in values in units of quarter-us, not us, since all other `raestro` APIs expect values in units of quarter-us
+	* docs were updated to reflect this change

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -79,7 +79,7 @@ pub enum Error {
 #[doc(hidden)]
 impl Error {
     /// Constructs a `std::io::Error` from the
-    /// given parameters
+    /// given parameters.
     pub(crate) fn new_io_error<E>(err_kind: IoErrorKind, err_msg: E) -> Self
     where
         E: Into<Box<dyn StdError + Send + Sync>>,
@@ -95,9 +95,9 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Error::Uninitialized => write!(f, "maestro struct is uninitialized; please consider calling .start() on the instance first"),
-            Error::InvalidValue(value) => write!(f, "microsec values must be between 992us and 2000us but {}us was used", value),
-            Error::FaultyRead { actual_count, } => write!(f, "2 bytes were expected to be read, but only {} bytes were actually read", actual_count),
-            Error::FaultyWrite { actual_count, expected_count, } => write!(f, "{} bytes were expected to be written, but only {} bytes were actually written", expected_count, actual_count),
+            Error::InvalidValue(value) => write!(f, "target must be between 3968 quarter-us (992us) and 8000 quarter-us (2000us) but {} quarter-us was used", value),
+            Error::FaultyRead { actual_count, } => write!(f, "2 bytes were expected to be read, but only {} byte(s) were actually read", actual_count),
+            Error::FaultyWrite { actual_count, expected_count, } => write!(f, "{} bytes were expected to be written, but only {} byte(s) were actually written", expected_count, actual_count),
             Error::Io(io_error) => io_error.fmt(f),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! instance, as well as how to send some commands
 //! to the Micro Maestro 6-Channel Servo Board.
 //!
-//! ```ignore
+//! ```
 //! use std::{
 //!     thread,
 //!     time::Duration,
@@ -89,16 +89,17 @@
 //!
 //! let channel: Channels = Channels::C_0;
 //!
-//! let pos_min = 992u16;
-//! let pos_max = 2000u16;
+//! let target_min = 3968u16;
+//! let target_max = 8000u16;
 //!
 //! let sleep_time = Duration::from_millis(1000u64);
 //!
-//! loop {
-//!     m.set_target(channel, pos_min).unwrap();
+//! // just swivel back and forth 10 times
+//! for _ in 0u8..10u8 {
+//!     m.set_target(channel, target_min).unwrap();
 //!     thread::sleep(sleep_time);
 //!
-//!     m.set_target(channel, pos_max).unwrap();
+//!     m.set_target(channel, target_max).unwrap();
 //!     thread::sleep(sleep_time);
 //! }
 //! ```

--- a/src/maestro.rs
+++ b/src/maestro.rs
@@ -104,10 +104,10 @@ impl Maestro {
     /// prevent any leakage of `maestro` instances
     /// into the `invalid` state.
     pub fn start(&mut self, baud_rate: BaudRates) -> Result<()> {
-        let uart_result: RppalResult<Uart> =
+        let result: RppalResult<Uart> =
             Uart::new(baud_rate as u32, Parity::None, DATA_BITS, STOP_BITS);
 
-        uart_result
+        result
             .and_then(|uart| {
                 self.uart = Some(Box::new(uart));
                 self.read_buf = Some(Box::new([0u8; BUFFER_SIZE]));
@@ -117,7 +117,7 @@ impl Maestro {
                     .as_mut()
                     .unwrap()
                     .as_mut()
-                    .set_read_mode(RESPONSE_SIZE, DEFAULT_BLOCKING_DURATION)
+                    .set_read_mode(0u8, DEFAULT_BLOCKING_DURATION)
             })
             .map(|()| {
                 let buf = self.write_buf.as_mut().unwrap().as_mut();
@@ -172,7 +172,7 @@ impl Maestro {
             .as_mut()
             .ok_or(Error::Uninitialized)
             .and_then(|uart| {
-                uart.set_read_mode(RESPONSE_SIZE, duration)
+                uart.set_read_mode(0u8, duration)
                     .map_err(Error::from)
             })
     }
@@ -373,13 +373,13 @@ impl Maestro {
     /// m.start(BaudRates::BR_115200).unwrap();
     ///
     /// let channel: Channels = Channels::C_0; // can be any arbitrary channel in the Channels enum
-    /// let target = 1234u16; // can be any value between 3968u16 and 8000u16
+    /// let target = 4000u16; // can be any value between 3968u16 and 8000u16
     ///
     /// m.set_target(channel, target);
     ///
     /// let actual_position = m.get_position(channel).unwrap();
     ///
-    /// assert_eq!(position, actual_position);
+    /// assert_eq!(target, actual_position);
     /// ```
     pub fn get_position(&mut self, channel: Channels) -> Result<u16> {
         let write_result = self.write_channel(CommandFlags::GET_POSITION, channel);

--- a/src/maestro.rs
+++ b/src/maestro.rs
@@ -171,10 +171,7 @@ impl Maestro {
         self.uart
             .as_mut()
             .ok_or(Error::Uninitialized)
-            .and_then(|uart| {
-                uart.set_read_mode(0u8, duration)
-                    .map_err(Error::from)
-            })
+            .and_then(|uart| uart.set_read_mode(0u8, duration).map_err(Error::from))
     }
 }
 


### PR DESCRIPTION
Maestro::set_target min and max values updated to expect quarter-us now instead (thus, 3969-8000)
docs were updated

Maestro::read was incorrectly configured to infinitely wait until something was read on the `uart` lines; updated to wait only default/configured duration values